### PR TITLE
Add testID support to shared input components (E2E readiness)

### DIFF
--- a/e2e-mobile-tests/tests/locators/SignUpLocators.ts
+++ b/e2e-mobile-tests/tests/locators/SignUpLocators.ts
@@ -1,5 +1,185 @@
 const signUpLocators = {
+  /* =====================================================
+        CREATE MASTER PASSWORD
+  ===================================================== */
 
+  createPasswordScreenAndroid: '~create_password_screen',
+  createPasswordScreeniOS: '~create_password_screen',
+
+  createPasswordLogoAndroid: '~create_password_logo',
+  createPasswordLogoiOS: '~create_password_logo',
+
+  createPasswordTitleAndroid: '~create_password_title',
+  createPasswordTitleiOS: '~create_password_title',
+
+  createPasswordDescriptionAndroid: '~create_password_description',
+  createPasswordDescriptioniOS: '~create_password_description',
+
+  createPasswordInputAndroid: '~create_password_input',
+  createPasswordInputiOS: '~create_password_input',
+
+  createPasswordConfirmInputAndroid: '~create_password_confirm_input',
+  createPasswordConfirmInputiOS: '~create_password_confirm_input',
+
+  createPasswordRequirementsContainerAndroid: '~create_password_requirements_container',
+  createPasswordRequirementsContaineriOS: '~create_password_requirements_container',
+
+  createPasswordRequirementsTextAndroid: '~create_password_requirements_text',
+  createPasswordRequirementsTextiOS: '~create_password_requirements_text',
+
+  createPasswordRequirementUppercaseAndroid: '~create_password_requirement_uppercase',
+  createPasswordRequirementUppercaseiOS: '~create_password_requirement_uppercase',
+
+  createPasswordRequirementLowercaseAndroid: '~create_password_requirement_lowercase',
+  createPasswordRequirementLowercaseiOS: '~create_password_requirement_lowercase',
+
+  createPasswordRequirementNumberAndroid: '~create_password_requirement_number',
+  createPasswordRequirementNumberiOS: '~create_password_requirement_number',
+
+  createPasswordRequirementSpecialAndroid: '~create_password_requirement_special',
+  createPasswordRequirementSpecialiOS: '~create_password_requirement_special',
+
+  createPasswordRequirementNoteAndroid: '~create_password_requirement_note',
+  createPasswordRequirementNoteiOS: '~create_password_requirement_note',
+
+  createPasswordWarningAndroid: '~create_password_warning',
+  createPasswordWarningiOS: '~create_password_warning',
+
+  createPasswordTermsTitleAndroid: '~create_password_terms_title',
+  createPasswordTermsTitleiOS: '~create_password_terms_title',
+
+  createPasswordTermsCheckboxAndroid: '~create_password_terms_checkbox',
+  createPasswordTermsCheckboxiOS: '~create_password_terms_checkbox',
+
+  createPasswordTermsLinkAndroid: '~create_password_terms_link',
+  createPasswordTermsLinkiOS: '~create_password_terms_link',
+
+  createPasswordContinueButtonAndroid: '~create_password_continue_button',
+  createPasswordContinueButtoniOS: '~create_password_continue_button',
+
+  createPasswordLoadingAndroid: '~create_password_loading',
+  createPasswordLoadingiOS: '~create_password_loading',
+
+  /* =====================================================
+        ENTER MASTER PASSWORD
+  ===================================================== */
+
+  enterPasswordScreenAndroid: '~enter_password_screen',
+  enterPasswordScreeniOS: '~enter_password_screen',
+
+  enterPasswordLogoAndroid: '~enter_password_logo',
+  enterPasswordLogoiOS: '~enter_password_logo',
+
+  enterPasswordTitleAndroid: '~enter_password_title',
+  enterPasswordTitleiOS: '~enter_password_title',
+
+  enterPasswordInputAndroid: '~enter_password_input',
+  enterPasswordInputiOS: '~enter_password_input',
+
+  enterPasswordWarningAndroid: '~enter_password_warning',
+  enterPasswordWarningiOS: '~enter_password_warning',
+
+  enterPasswordContinueButtonAndroid: '~enter_password_continue_button',
+  enterPasswordContinueButtoniOS: '~enter_password_continue_button',
+
+  enterPasswordBiometricButtonAndroid: '~enter_password_biometric_button',
+  enterPasswordBiometricButtoniOS: '~enter_password_biometric_button',
+
+  enterPasswordLoadingAndroid: '~enter_password_loading',
+  enterPasswordLoadingiOS: '~enter_password_loading',
+
+  /* =====================================================
+        SELECT VAULT TYPE
+  ===================================================== */
+
+  selectVaultTypeScreenAndroid: '~select_vault_type_screen',
+  selectVaultTypeScreeniOS: '~select_vault_type_screen',
+
+  selectVaultTypeLogoAndroid: '~select_vault_type_logo',
+  selectVaultTypeLogoiOS: '~select_vault_type_logo',
+
+  selectVaultTypeEmptyTitleAndroid: '~select_vault_type_empty_title',
+  selectVaultTypeEmptyTitleiOS: '~select_vault_type_empty_title',
+
+  selectVaultTypeEmptySubtitleAndroid: '~select_vault_type_empty_subtitle',
+  selectVaultTypeEmptySubtitleiOS: '~select_vault_type_empty_subtitle',
+
+  selectVaultTypeListTitleAndroid: '~select_vault_type_list_title',
+  selectVaultTypeListTitleiOS: '~select_vault_type_list_title',
+
+  selectVaultTypeVaultListAndroid: '~select_vault_type_vault_list',
+  selectVaultTypeVaultListiOS: '~select_vault_type_vault_list',
+
+  selectVaultTypeVaultItemAndroid: '~select_vault_type_vault_item_',
+  selectVaultTypeVaultItemiOS: '~select_vault_type_vault_item_',
+
+  selectVaultTypeCreateNewAndroid: '~select_vault_type_create_new',
+  selectVaultTypeCreateNewiOS: '~select_vault_type_create_new',
+
+  selectVaultTypeLoadExistingAndroid: '~select_vault_type_load_existing',
+  selectVaultTypeLoadExistingiOS: '~select_vault_type_load_existing',
+
+  /* =====================================================
+        LOAD VAULT
+  ===================================================== */
+
+  loadVaultScreenAndroid: '~load_vault_screen',
+  loadVaultScreeniOS: '~load_vault_screen',
+
+  loadVaultLogoAndroid: '~load_vault_logo',
+  loadVaultLogoiOS: '~load_vault_logo',
+
+  loadVaultTitleAndroid: '~load_vault_title',
+  loadVaultTitleiOS: '~load_vault_title',
+
+  loadVaultSubtitleAndroid: '~load_vault_subtitle',
+  loadVaultSubtitleiOS: '~load_vault_subtitle',
+
+  loadVaultInviteCodeInputAndroid: '~load_vault_invite_code_input',
+  loadVaultInviteCodeInputiOS: '~load_vault_invite_code_input',
+
+  loadVaultOpenButtonAndroid: '~load_vault_open_button',
+  loadVaultOpenButtoniOS: '~load_vault_open_button',
+
+  loadVaultSelectVaultsButtonAndroid: '~load_vault_select_vaults_button',
+  loadVaultSelectVaultsButtoniOS: '~load_vault_select_vaults_button',
+
+  loadVaultCancelPairingButtonAndroid: '~load_vault_cancel_pairing_button',
+  loadVaultCancelPairingButtoniOS: '~load_vault_cancel_pairing_button',
+
+  loadVaultScanQrButtonAndroid: '~load_vault_scan_qr_button',
+  loadVaultScanQrButtoniOS: '~load_vault_scan_qr_button',
+
+  loadVaultLoadingAndroid: '~load_vault_loading',
+  loadVaultLoadingiOS: '~load_vault_loading',
+
+  /* =====================================================
+        UNLOCK VAULT
+  ===================================================== */
+
+  unlockVaultScreenAndroid: '~unlock_vault_screen',
+  unlockVaultScreeniOS: '~unlock_vault_screen',
+
+  unlockVaultScrollAndroid: '~unlock_vault_scroll',
+  unlockVaultScrolliOS: '~unlock_vault_scroll',
+
+  unlockVaultFormContainerAndroid: '~unlock_vault_form_container',
+  unlockVaultFormContaineriOS:'~unlock_vault_form_container',
+
+  unlockVaultTitleAndroid: '~unlock_vault_title',
+  unlockVaultTitleiOS: '~unlock_vault_title',
+
+  unlockVaultPasswordInputAndroid: '~unlock_vault_password_input',
+  unlockVaultPasswordInputiOS: '~unlock_vault_password_input',
+
+  unlockVaultContinueButtonAndroid: '~unlock_vault_continue_button',
+  unlockVaultContinueButtoniOS: '~unlock_vault_continue_button',
+
+  unlockVaultSelectVaultsButtonAndroid: '~unlock_vault_select_vaults_button',
+  unlockVaultSelectVaultsButtoniOS: '~unlock_vault_select_vaults_button',
+
+  unlockVaultLoadingAndroid: '~unlock_vault_loading',
+  unlockVaultLoadingiOS: '~unlock_vault_loading'
 }
 
 export default signUpLocators

--- a/e2e-mobile-tests/tests/pageobjects/SignUpPage.ts
+++ b/e2e-mobile-tests/tests/pageobjects/SignUpPage.ts
@@ -5,8 +5,8 @@ class SignUpPage extends BasePage {
   protected selectors = signUpLocators
 
   async waitForLoaded(): Promise<void> {
-    await this.waitForDisplayed('onboardingLogo')
-    await this.waitForDisplayed('onboardingProgressBar')
+    await this.waitForDisplayed('')
+    await this.waitForDisplayed('')
   }
 }
 

--- a/src/components/AppWarning/index.jsx
+++ b/src/components/AppWarning/index.jsx
@@ -4,16 +4,25 @@ import { View, Text, StyleSheet } from 'react-native'
 
 /**
  * @param {{
+ *  testID?: string,
  *  warning: string,
  *  containerStyles: object,
  *  textStyles: object
  * }} props
  * @returns
  */
-export const AppWarning = ({ warning, containerStyles, textStyles }) => (
-  <View style={[styles.warningContainer, containerStyles]}>
+export const AppWarning = ({ testID, warning, containerStyles, textStyles }) => (
+  <View
+    testID={testID}
+    nativeID={testID}
+    accessibilityLabel={testID}
+    style={[styles.warningContainer, containerStyles]}>
     <YellowErrorIcon width={14} height={14} />
-    <Text style={[styles.warningText, textStyles]}>{warning}</Text>
+    <Text 
+    testID={testID ? `${testID}-text` : undefined}
+    nativeID={testID ? `${testID}-text` : undefined}
+    accessibilityLabel={testID ? `${testID}-text` : undefined}
+    style={[styles.warningText, textStyles]}>{warning}</Text>
   </View>
 )
 const styles = StyleSheet.create({

--- a/src/components/AppWarning/index.test.jsx
+++ b/src/components/AppWarning/index.test.jsx
@@ -27,9 +27,10 @@ const renderWithProviders = (ui) =>
 describe('AppWarning', () => {
   it('renders correctly with default styles', () => {
     const { getByTestId, toJSON, getByText } = renderWithProviders(
-      <AppWarning warning="Test warning" />
+      <AppWarning testID="app-warning" warning="Test warning" />
     )
-
+    expect(getByTestId('app-warning')).toBeTruthy()
+    expect(getByTestId('app-warning-text')).toBeTruthy()
     expect(getByTestId('yellow-error-icon')).toBeTruthy()
     expect(getByText('Test warning')).toBeTruthy()
     expect(toJSON()).toMatchSnapshot()

--- a/src/containers/Auth/CreatePassword.jsx
+++ b/src/containers/Auth/CreatePassword.jsx
@@ -284,16 +284,34 @@ export const CreatePassword = () => {
                     <View style={styles.checkboxEmpty} testID="create-password-terms-checkbox-unchecked" />
                   )}
                 </TouchableOpacity>
-                <View style={styles.textContainer}>
-                  <Text style={styles.bottomText}>
-                    {t`I have read and agree to the`}{' '}
-                    <Text style={styles.linkText} onPress={handleTermsPress}
-                    testID="create-password-terms-link"
-                    accessibilityLabel="create-password-terms-link">
+                  <View style={styles.textContainer}>
+                    <View
+                      style={styles.termsTextRow}
+                      testID="create-password-terms-text-row"
+                      nativeID="create-password-terms-text-row"
+                      accessibilityLabel="create-password-terms-text-row"
+                    >
+                    <Text
+                      style={styles.bottomText}
+                      testID="create-password-terms-text"
+                      nativeID="create-password-terms-text"
+                      accessibilityLabel="create-password-terms-text"
+                    >
+                      {t`I have read and agree to the`}{' '}
+                    </Text>
+
+                    <Text
+                      style={[styles.bottomText, styles.linkText]}
+                      onPress={handleTermsPress}
+                      testID="create-password-terms-link"
+                      nativeID="create-password-terms-link"
+                      accessibilityLabel="create-password-terms-link"
+                    >
                       {t`PearPass Application Terms of Use`}
                     </Text>
-                    .
-                  </Text>
+
+                    <Text style={styles.bottomText}>.</Text>
+                  </View>
                 </View>
               </View>
             </View>
@@ -455,5 +473,10 @@ const styles = StyleSheet.create({
     color: colors.grey100.mode1,
     fontSize: 14,
     fontFamily: 'Inter'
+  },
+  termsTextRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'flex-start'
   }
 })

--- a/src/containers/OnboardingContainer/index.jsx
+++ b/src/containers/OnboardingContainer/index.jsx
@@ -168,32 +168,32 @@ export const OnboardingContainer = ({
         )
       case 2:
         return (
-          <View
+          <Rive
+            resourceName="password"
+            style={styles.riveAnimation}
             testID="onboarding-media-step-2"
             accessibilityLabel="onboarding-media-step-2"
-          >
-            <Rive resourceName="password" style={styles.riveAnimation} />
-          </View>
-        )
+    />
+  )
 
       case 3:
         return (
-          <View
+          <Rive
+            resourceName="category"
+            style={styles.riveAnimation}
             testID="onboarding-media-step-3"
             accessibilityLabel="onboarding-media-step-3"
-          >
-            <Rive resourceName="category" style={styles.riveAnimation} />
-          </View>
+    />
   )
 
       case 4:
         return (
-          <View
+          <Rive
+            resourceName="form"
+            style={styles.riveAnimationForm}
             testID="onboarding-media-step-4"
             accessibilityLabel="onboarding-media-step-4"
-          >
-            <Rive resourceName="form" style={styles.riveAnimationForm} />
-          </View>
+    />
   )
       case 5:
         return (
@@ -381,15 +381,17 @@ export const OnboardingContainer = ({
         style={styles.bottomSection}>
           <Text 
           testID="onboarding-main-description"
+          nativeID="onboarding-main-description"
           accessibilityLabel="onboarding-main-description"
           style={styles.descriptionText}>{mainDescription}</Text>
 
           {getSubDescriptionContent() && (
-            <View 
-            testID="onboarding-sub-description"
-            accessibilityLabel="onboarding-sub-description"   
-            style={styles.subDescriptionWrapper}>
-              <Text style={styles.subDescriptionText}>
+            <View style={styles.subDescriptionWrapper}>
+              <Text style={styles.subDescriptionText}
+                testID="onboarding-sub-description"
+                nativeID="onboarding-sub-description"
+                accessibilityLabel="onboarding-sub-description"
+              >
                 {getSubDescriptionContent()}
               </Text>
             </View>

--- a/src/libComponents/ButtonCreate/index.jsx
+++ b/src/libComponents/ButtonCreate/index.jsx
@@ -8,15 +8,25 @@ import { Button, ButtonText } from './styles'
  *  children: ReactNode
  *  startIcon?: ElementType
  *  onPress: () => void
+ *  testID?: string
+ *  accessibilityLabel?: string
+ *  nativeID?: string
  * }} props
  */
-export const ButtonCreate = ({ children, startIcon, onPress }) => {
+export const ButtonCreate = ({ children, startIcon, onPress, testID, accessibilityLabel, nativeID }) => {
   const Icon = startIcon
   return (
-    <Button activeOpacity={0.8} onPress={onPress}>
+    <Button
+      testID={testID}
+      nativeID={nativeID ?? testID}
+      accessibilityLabel={accessibilityLabel ?? testID}
+      accessibilityRole="button"
+      activeOpacity={0.8}
+      onPress={onPress}
+    >
       {Icon && <Icon size="21" color={colors.black.mode1} />}
       {children && <ButtonText>{children}</ButtonText>}
-      <View></View>
+      <View />
     </Button>
   )
 }

--- a/src/libComponents/ButtonCreate/index.test.js
+++ b/src/libComponents/ButtonCreate/index.test.js
@@ -49,4 +49,16 @@ describe('ButtonCreate Component', () => {
     )
     expect(toJSON()).toMatchSnapshot()
   })
+
+  test('passes testID to native button', () => {
+    const onPressMock = jest.fn()
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <ButtonCreate testID="button-create" onPress={onPressMock}>
+          Create
+        </ButtonCreate>
+      </ThemeProvider>
+    )
+    expect(getByTestId('button-create')).toBeTruthy()
+  })
 })

--- a/src/libComponents/ButtonPrimary/index.jsx
+++ b/src/libComponents/ButtonPrimary/index.jsx
@@ -7,6 +7,9 @@ import { ButtonText, Button } from './styles'
  *  size?: 'sm' | 'md'
  *  stretch: boolean
  *  onPress: () => void
+ *  testID?: string
+ *  accessibilityLabel?: string
+ *  nativeID?: string
  * }} props
  */
 export const ButtonPrimary = ({
@@ -14,9 +17,16 @@ export const ButtonPrimary = ({
   onPress,
   size = 'md',
   stretch,
-  disabled
+  disabled,
+  testID,
+  accessibilityLabel,
+  nativeID
 }) => (
   <Button
+    testID={testID}
+    nativeID={nativeID ?? testID}
+    accessibilityLabel={accessibilityLabel ?? testID}
+    accessibilityRole="button"
     size={size}
     onPress={disabled ? undefined : onPress}
     stretch={stretch}

--- a/src/libComponents/ButtonPrimary/index.test.js
+++ b/src/libComponents/ButtonPrimary/index.test.js
@@ -55,4 +55,16 @@ describe('ButtonPrimary Component', () => {
     )
     expect(toJSON()).toMatchSnapshot()
   })
+
+  test('passes testID to native button', () => {
+    const onPressMock = jest.fn()
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <ButtonPrimary testID="primary-btn" onPress={onPressMock} stretch={false}>
+          Primary Button
+        </ButtonPrimary>
+      </ThemeProvider>
+    )
+    expect(getByTestId('primary-btn')).toBeTruthy()
+  })
 })

--- a/src/libComponents/ButtonSecondary/index.jsx
+++ b/src/libComponents/ButtonSecondary/index.jsx
@@ -8,6 +8,9 @@ import { Button, ButtonText } from './styles'
  *  stretch: boolean
  *  onPress: () => void
  *  disabled?: boolean
+ *  testID?: string
+ *  accessibilityLabel?: string
+ *  nativeID?: string
  * }} props
  */
 export const ButtonSecondary = ({
@@ -15,9 +18,16 @@ export const ButtonSecondary = ({
   onPress,
   size = 'md',
   stretch,
-  disabled = false
+  disabled = false,
+  testID,
+  accessibilityLabel,
+  nativeID
 }) => (
   <Button
+    testID={testID}
+    nativeID={nativeID ?? testID}
+    accessibilityLabel={accessibilityLabel ?? testID}
+    accessibilityRole="button"
     size={size}
     onPress={disabled ? undefined : onPress}
     stretch={stretch}

--- a/src/libComponents/ButtonSecondary/index.test.js
+++ b/src/libComponents/ButtonSecondary/index.test.js
@@ -41,4 +41,16 @@ describe('ButtonSecondary Component', () => {
     )
     expect(toJSON()).toMatchSnapshot()
   })
+
+  test('passes testID to native button', () => {
+    const onPressMock = jest.fn()
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <ButtonSecondary testID="button-secondary" onPress={onPressMock} stretch={false}>
+          Secondary Button
+        </ButtonSecondary>
+      </ThemeProvider>
+    )
+    expect(getByTestId('button-secondary')).toBeTruthy()
+  })
 })

--- a/src/libComponents/CompoundField/index.jsx
+++ b/src/libComponents/CompoundField/index.jsx
@@ -4,10 +4,18 @@ import { CompoundFieldComponent } from './styles'
  * @param {{
  * children: ReactNode
  * isDisabled: boolean
+ * testID?: string
+ * accessibilityLabel?: string
+ * nativeID?: string
  * }} props
  */
-export const CompoundField = ({ children, isDisabled }) => (
-  <CompoundFieldComponent isDisabled={isDisabled}>
+export const CompoundField = ({ children, isDisabled, testID, accessibilityLabel, nativeID }) => (
+  <CompoundFieldComponent 
+    isDisabled={isDisabled}
+    testID={testID}
+    nativeID={nativeID ?? testID}
+    accessibilityLabel={accessibilityLabel ?? testID}
+  >
     {children}
   </CompoundFieldComponent>
 )

--- a/src/libComponents/CompoundField/index.test.js
+++ b/src/libComponents/CompoundField/index.test.js
@@ -37,4 +37,15 @@ describe('CompoundField Component', () => {
     )
     expect(toJSON()).toMatchSnapshot()
   })
+
+  test('passes testID to wrapper', () => {
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <CompoundField testID="compound-field">
+          <Text>Child Content</Text>
+        </CompoundField>
+      </ThemeProvider>
+    )
+    expect(getByTestId('compound-field')).toBeTruthy()
+  })
 })

--- a/src/libComponents/InputField/index.jsx
+++ b/src/libComponents/InputField/index.jsx
@@ -39,7 +39,11 @@ import { HighlightString } from '../HighlightString'
  *  variant?: 'default' | 'outline',
  *  isTransparent: boolean,
  *  belowInputContent?: React.ReactNode,
- *  shouldDisplayCustomPlaceholder?: boolean
+ *  shouldDisplayCustomPlaceholder?: boolean,
+ *  testID?: string,
+ *  inputTestID?: string,
+ *  accessibilityLabel?: string,
+ *  nativeID?: string
  * }} props
  */
 export const InputField = ({
@@ -65,7 +69,11 @@ export const InputField = ({
   index,
   isTransparent = false,
   belowInputContent,
-  shouldDisplayCustomPlaceholder = false
+  shouldDisplayCustomPlaceholder = false,
+  testID,
+  inputTestID,
+  accessibilityLabel,
+  nativeID
 }) => {
   const inputRef = useRef(null)
   const [isFocused, setIsFocused] = useState(false)
@@ -188,6 +196,9 @@ export const InputField = ({
           ) : (
             <TextInput
               ref={inputRef}
+              testID={inputTestID ?? testID}
+              nativeID={(inputTestID ?? testID) ? (inputTestID ?? testID) : undefined}
+              accessibilityLabel={inputTestID ?? testID}
               value={value}
               onChangeText={handleChange}
               placeholder={shouldDisplayCustomPlaceholder ? '' : placeholder}
@@ -257,7 +268,12 @@ export const InputField = ({
 
   if (isDisabled && onClick) {
     return (
-      <View style={getWrapperStyle()}>
+      <View 
+        style={getWrapperStyle()}
+        testID={testID}
+        nativeID={nativeID ?? testID}
+        accessibilityLabel={accessibilityLabel ?? testID}
+      >
         {InputContent}
         {!!belowInputContent && belowInputContent}
       </View>
@@ -266,6 +282,9 @@ export const InputField = ({
 
   return (
     <TouchableOpacity
+      testID={testID}
+      nativeID={nativeID ?? testID}
+      accessibilityLabel={accessibilityLabel ?? testID}
       onPress={handleClick}
       style={getWrapperStyle()}
       accessible={false}

--- a/src/libComponents/InputField/index.test.js
+++ b/src/libComponents/InputField/index.test.js
@@ -155,4 +155,19 @@ describe('InputField Component', () => {
     )
     expect(toJSON()).toMatchSnapshot()
   })
+
+  test('passes testID to TextInput', () => {
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <InputField
+          testID="input-field"
+          value=""
+          placeholder="Enter value"
+          isSecure={false}
+          isColored={false}
+        />
+      </ThemeProvider>
+    )
+    expect(getByTestId('input-field')).toBeTruthy()
+  })
 })

--- a/src/libComponents/InputPasswordPearPass/index.jsx
+++ b/src/libComponents/InputPasswordPearPass/index.jsx
@@ -34,6 +34,7 @@ import {
  * }} props
  */
 export const InputPasswordPearPass = ({
+  testID,
   value,
   onChange,
   error,
@@ -65,6 +66,7 @@ export const InputPasswordPearPass = ({
 
   return (
     <InputWrapper
+      testID={testID ? `${testID}-wrapper` : undefined}
       onPress={handleClick}
       isFirst={isFirst}
       isLast={isLast}
@@ -72,7 +74,7 @@ export const InputPasswordPearPass = ({
       isPassword={isPassword}
     >
       {isPassword && (
-        <IconWrapper>
+        <IconWrapper testID={testID ? `${testID}-lock-icon` : undefined}>
           <LockCircleIcon size="21" />
         </IconWrapper>
       )}
@@ -80,6 +82,9 @@ export const InputPasswordPearPass = ({
       <MainWrapper>
         <Input
           ref={inputRef}
+          testID={testID}
+          nativeID={testID}
+          accessibilityLabel={testID}
           value={value}
           onChangeText={handleChange}
           placeholder={placeholder}
@@ -97,7 +102,7 @@ export const InputPasswordPearPass = ({
         />
 
         {!!error?.length && (
-          <ErrorMessageWrapper>
+          <ErrorMessageWrapper testID={testID ? `${testID}-error` : undefined}>
             <ErrorIcon size="10" />
             <ErrorMessage> {error} </ErrorMessage>
           </ErrorMessageWrapper>
@@ -106,6 +111,7 @@ export const InputPasswordPearPass = ({
       {isPassword && (
         <AdditionalItems>
           <ButtonLittle
+            testID={testID ? `${testID}-toggle-visibility` : undefined}
             variant="secondary"
             borderRadius="md"
             onPress={() => setIsVisible(!isVisible)}

--- a/src/libComponents/PasswordField/index.jsx
+++ b/src/libComponents/PasswordField/index.jsx
@@ -48,6 +48,9 @@ const PASSWORD_STRENGTH_ICONS = {
  *  type?: 'numeric' | 'default',
  *  belowInputContent?: React.ReactNode,
  *  shouldDisplayCustomPlaceholder?: boolean,
+ *  testID?: string,
+ *  inputTestID?: string,
+ *  toggleTestID?: string
  * }} props
  */
 export const PasswordField = ({
@@ -71,7 +74,10 @@ export const PasswordField = ({
   type = 'default',
   icon,
   belowInputContent,
-  shouldDisplayCustomPlaceholder = false
+  shouldDisplayCustomPlaceholder = false,
+  testID,
+  inputTestID,
+  toggleTestID
 }) => {
   const { t } = useLingui()
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
@@ -119,6 +125,8 @@ export const PasswordField = ({
   return (
     <View>
       <InputField
+        testID={testID ? `${testID}-field` : undefined}
+        inputTestID={inputTestID ?? (testID ? `${testID}-input` : undefined)}
         label={label || 'Password'}
         variant="outline"
         icon={icon || KeyIcon}
@@ -144,6 +152,8 @@ export const PasswordField = ({
             {!!hasStrongness && getPasswordStrength()}
             {!!additionalItems && additionalItems}
             <ButtonLittle
+              testID={toggleTestID ?? (testID ? `${testID}-toggle` : undefined)}
+              accessibilityLabel={toggleTestID ?? (testID ? `${testID}-toggle` : undefined)}
               variant="secondary"
               borderRadius="md"
               startIcon={isPasswordVisible ? EyeClosedIcon : EyeIcon}

--- a/src/libComponents/PasswordField/index.test.js
+++ b/src/libComponents/PasswordField/index.test.js
@@ -171,4 +171,28 @@ describe('PasswordField Component', () => {
 
     expect(input.props.secureTextEntry).toBe(true)
   })
+
+  test('passes inputTestID to password input', () => {
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <PasswordField
+          {...defaultProps}
+          inputTestID="password-input"
+        />
+      </ThemeProvider>
+    )
+    expect(getByTestId('password-input')).toBeTruthy()
+  })
+
+  test('renders visibility toggle with testID', () => {
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <PasswordField
+          {...defaultProps}
+          toggleTestID="password-toggle"
+        />
+      </ThemeProvider>
+    )
+    expect(getByTestId('password-toggle')).toBeTruthy()
+  })
 })


### PR DESCRIPTION
This PR adds testID support to shared input components to improve mobile E2E automation.
IDs are now available both on the wrapper and on the underlying TextInput.

No functional or UI changes were introduced.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212508942478666