### PR TITLE
chore(ui): add and fix testIDs for signup and onboarding screens

### DIFF
--- a/src/containers/Auth/CreatePassword.jsx
+++ b/src/containers/Auth/CreatePassword.jsx
@@ -200,9 +200,9 @@ export const CreatePassword = () => {
   )
 
   return (
-    <View style={styles.container} testID="create-password-screen">
+    <View style={styles.container} testID="create-password-screen" accessibilityLabel="create-password-screen">
       {!isKeyboardVisible && (
-        <View style={styles.logoContainer} testID="create-password-logo">
+        <View style={styles.logoContainer} testID="create-password-logo" accessibilityLabel="create-password-logo">
           <LogoTextWithLock width={170} height={50} />
         </View>
       )}
@@ -217,16 +217,17 @@ export const CreatePassword = () => {
           showsVerticalScrollIndicator={false}
           keyboardShouldPersistTaps="handled"
         >
-          <View style={styles.formContainer} testID="create-password-form-container">
+          <View style={styles.formContainer} testID="create-password-form-container" accessibilityLabel="create-password-form-container">
             <View style={styles.headerContainer}>
-              <Text style={styles.headerText} testID="create-password-title">{t`Create Master Password`}</Text>
+              <Text style={styles.headerText} testID="create-password-title" accessibilityLabel="create-password-title">{t`Create Master Password`}</Text>
             </View>
             <Text
-              style={styles.boldText} testID="create-password-description"
+              style={styles.boldText} testID="create-password-description" accessibilityLabel="create-password-description"
             >{t`The first thing to do is create a Master password to secure your account.  You’ll use this password to access PearPass. `}</Text>
-            <View style={styles.inputContainer} testID="create-password-inputs-container">
+            <View style={styles.inputContainer} testID="create-password-inputs-container" accessibilityLabel="create-password-inputs-container">
               <InputPasswordPearPass
                 testID="create-password-input"
+                accessibilityLabel="create-password-input"
                 placeholder={t`Enter Password`}
                 {...passwordRegisterProps}
                 onChange={handlePasswordChange}
@@ -235,53 +236,54 @@ export const CreatePassword = () => {
 
               <InputPasswordPearPass
                 testID="create-password-confirm-input"
+                accessibilityLabel="create-password-confirm-input"
                 placeholder={t`Confirm Password`}
                 {...register('passwordConfirm')}
                 isPassword
               />
             </View>
 
-            <View style={styles.requirementsContainer} testID="create-password-requirements-container">
-              <Text style={styles.requirementsText} testID="create-password-requirements-text">
+            <View style={styles.requirementsContainer} testID="create-password-requirements-container" accessibilityLabel="create-password-requirements-container">
+              <Text style={styles.requirementsText} testID="create-password-requirements-text" accessibilityLabel="create-password-requirements-text">
                 {t`Your password must be at least 8 characters long and include at least one of each:`}
               </Text>
-              <View style={styles.bulletList} testID="create-password-requirements-list">
-                <Text style={styles.bulletItem} testID="create-password-requirement-uppercase">
+              <View style={styles.bulletList} testID="create-password-requirements-list" accessibilityLabel="create-password-requirements-list">
+                <Text style={styles.bulletItem} testID="create-password-requirement-uppercase" accessibilityLabel="create-password-requirement-uppercase">
                   {`${bulletUnicode} ${t`Uppercase Letter (A-Z)`}`}
                 </Text>
-                <Text style={styles.bulletItem} testID="create-password-requirement-lowercase">
+                <Text style={styles.bulletItem} testID="create-password-requirement-lowercase" accessibilityLabel="create-password-requirement-lowercase">
                   {`${bulletUnicode} ${t`Lowercase Letter (a-z)`}`}
                 </Text>
-                <Text style={styles.bulletItem} testID="create-password-requirement-number">
+                <Text style={styles.bulletItem} testID="create-password-requirement-number" accessibilityLabel="create-password-requirement-number">
                   {`${bulletUnicode} ${t`Number (0-9)`}`}
                 </Text>
-                <Text style={styles.bulletItem} testID="create-password-requirement-special">
+                <Text style={styles.bulletItem} testID="create-password-requirement-special" accessibilityLabel="create-password-requirement-special">
                   {`${bulletUnicode} ${t`Special Character (! @ # $...)`}`}
                 </Text>
               </View>
-              <Text style={styles.noteText} testID="create-password-requirement-note">
+              <Text style={styles.noteText} testID="create-password-requirement-note" accessibilityLabel="create-password-requirement-note">
                 {t`Note: Avoid common words and personal information.`}
               </Text>
             </View>
 
-            <View style={styles.termsContainer} testID="create-password-terms-container">
-              <AppWarning testID="create-password-warning"
+            <View style={styles.termsContainer} testID="create-password-terms-container" accessibilityLabel="create-password-terms-container">
+              <AppWarning testID="create-password-warning" accessibilityLabel="create-password-warning"
                 warning={t`Don't forget your master password. It's the only way to access your vault. We can't help recover it. Back it up securely.`}
                 textStyles={{ flex: 0 }}
               />
-              <Text style={styles.termsTitle} testID="create-password-terms-title">{t`PearPass Terms of Use`}</Text>
+              <Text style={styles.termsTitle} testID="create-password-terms-title" accessibilityLabel="create-password-terms-title">{t`PearPass Terms of Use`}</Text>
 
-              <View style={styles.checkboxContainer} testID="create-password-terms-checkbox-row">
+              <View style={styles.checkboxContainer} testID="create-password-terms-checkbox-row" accessibilityLabel="create-password-terms-checkbox-row">
                 <TouchableOpacity 
                 testID="create-password-terms-checkbox"
                 accessibilityLabel="create-password-terms-checkbox"
                 onPress={() => setAccepted(!accepted)}>
                   {accepted ? (
-                    <View style={styles.checkboxOuter} testID="create-password-terms-checkbox-checked">
+                    <View style={styles.checkboxOuter} testID="create-password-terms-checkbox-checked" accessibilityLabel="create-password-terms-checkbox-checked">
                       <View style={styles.checkboxInner} />
                     </View>
                   ) : (
-                    <View style={styles.checkboxEmpty} testID="create-password-terms-checkbox-unchecked" />
+                    <View style={styles.checkboxEmpty} testID="create-password-terms-checkbox-unchecked" accessibilityLabel="create-password-terms-checkbox-unchecked" />
                   )}
                 </TouchableOpacity>
                   <View style={styles.textContainer}>
@@ -301,7 +303,7 @@ export const CreatePassword = () => {
                     </Text>
 
                     <Text
-                      style={[styles.bottomText, styles.linkText]}
+                      style={[styles.bottomText, styles.linkText, { flexShrink: 1 }]}
                       onPress={handleTermsPress}
                       testID="create-password-terms-link"
                       nativeID="create-password-terms-link"
@@ -315,16 +317,18 @@ export const CreatePassword = () => {
                 </View>
               </View>
             </View>
-            <View style={styles.buttonContainer} testID="create-password-actions-container">
+            <View style={styles.buttonContainer} testID="create-password-actions-container" accessibilityLabel="create-password-actions-container">
               {isLoading ? (
                 <ActivityIndicator
                   testID="create-password-loading"
+                  accessibilityLabel="create-password-loading"
                   size="small"
                   color={colors.primary400.mode1}
                 />
               ) : (
                 <ButtonPrimary
                   testID="create-password-continue-button"
+                  accessibilityLabel="create-password-continue-button"
                   stretch
                   onPress={handleSubmit(onSubmit)}
                   disabled={!accepted}

--- a/src/containers/Auth/EnterPassword.jsx
+++ b/src/containers/Auth/EnterPassword.jsx
@@ -102,15 +102,16 @@ export const EnterPassword = () => {
   }
 
   return (
-    <View style={styles.container} testID="enter-password-screen">
+    <View style={styles.container} testID="enter-password-screen" accessibilityLabel="enter-password-screen">
       {!isKeyboardVisible && (
-        <View style={styles.logoContainer} testID="enter-password-logo">
+        <View style={styles.logoContainer} testID="enter-password-logo" accessibilityLabel="enter-password-logo">
           <LogoTextWithLock width={170} height={50} />
         </View>
       )}
 
       <ScrollView
         testID="enter-password-scroll"
+        accessibilityLabel="enter-password-scroll"
         contentContainerStyle={[
           styles.scrollViewContent,
           { paddingBottom: keyboardHeight > 0 ? keyboardHeight + 20 : 40 }
@@ -119,13 +120,14 @@ export const EnterPassword = () => {
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"
       >
-        <View style={styles.formContainer} testID="enter-password-form-container">
+        <View style={styles.formContainer} testID="enter-password-form-container" accessibilityLabel="enter-password-form-container">
           <View style={styles.headerContainer}>
-            <Text style={styles.headerText} testID="enter-password-title">{t`Enter Master Password`}</Text>
+            <Text style={styles.headerText} testID="enter-password-title" accessibilityLabel="enter-password-title">{t`Enter Master Password`}</Text>
           </View>
 
           <View style={styles.inputContainer}>
             <InputPasswordPearPass testID="enter-password-input"
+              accessibilityLabel="enter-password-input"
               placeholder={t`Master password`}
               {...register('password')}
               isPassword
@@ -133,18 +135,20 @@ export const EnterPassword = () => {
           </View>
           <AppWarning
             testID="enter-password-warning"
+            accessibilityLabel="enter-password-warning"
             warning={t`Don't forget your master password. It's the only way to access your vault. We can't help recover it. Back it up securely.`}
           />
-          <View style={styles.buttonContainer} testID="enter-password-actions-container">
+          <View style={styles.buttonContainer} testID="enter-password-actions-container" accessibilityLabel="enter-password-actions-container">
             {isLoading ? (
-              <ActivityIndicator testID="enter-password-loading" size="small" color={colors.primary400.mode1} />
+              <ActivityIndicator testID="enter-password-loading" accessibilityLabel="enter-password-loading" size="small" color={colors.primary400.mode1} />
             ) : (
               <>
-                <ButtonPrimary testID="enter-password-continue-button" stretch onPress={handleSubmit(onSubmit)}>
-                  {t`Continue`}
+                <ButtonPrimary testID="enter-password-continue-button" accessibilityLabel="enter-password-continue-button" stretch onPress={handleSubmit(onSubmit)}>
+                  <Text testID="enter-password-continue-text" accessibilityLabel="enter-password-continue-text">{t`Continue`}</Text>
                 </ButtonPrimary>
 
                 <ButtonBiometricLogin testID="enter-password-biometric-button"
+                  accessibilityLabel="enter-password-biometric-button"
                   onBiometricLogin={(encryptionData) =>
                     onPasswordlessLogin(
                       encryptionData,

--- a/src/containers/Auth/LoadVault.jsx
+++ b/src/containers/Auth/LoadVault.jsx
@@ -54,13 +54,14 @@ export const LoadVault = () => {
   return (
     <KeyboardAvoidingView
       testID="load-vault-screen"
+      accessibilityLabel="load-vault-screen"
       style={{ flex: 1 }}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}
     >
       <View style={{ flex: 1 }}>
         {!isKeyboardVisible && (
-          <View style={styles.logoContainer} testID="load-vault-logo">
+          <View style={styles.logoContainer} testID="load-vault-logo" accessibilityLabel="load-vault-logo">
             <LogoTextWithLock width={170} height={50} />
           </View>
         )}
@@ -72,15 +73,16 @@ export const LoadVault = () => {
         >
           <View style={styles.formContainer}>
             <View style={{ marginBottom: 20, alignItems: 'center', gap: 10 }}>
-              <Text style={styles.title} testID="load-vault-title">{t`Load an existing Vault`}</Text>
+              <Text style={styles.title} testID="load-vault-title" accessibilityLabel="load-vault-title">{t`Load an existing Vault`}</Text>
               <Text
-                style={styles.subtitle} testID="load-vault-subtitle"
+                style={styles.subtitle} testID="load-vault-subtitle" accessibilityLabel="load-vault-subtitle"
               >{t`Open your vault with this code`}</Text>
             </View>
 
             <View style={{ width: '100%', gap: 15 }}>
               <InputPasswordPearPass
                 testID="load-vault-invite-code-input"
+                accessibilityLabel="load-vault-invite-code-input"
                 placeholder={t`Insert your vault's code...`}
                 value={inviteCode}
                 onChange={setInviteCode}
@@ -93,10 +95,11 @@ export const LoadVault = () => {
                 <>
                   <ActivityIndicator
                     testID="load-vault-loading"
+                    accessibilityLabel="load-vault-loading"
                     size="small"
                     color={colors.primary400.mode1}
                   />
-                  <ButtonSecondary testID="load-vault-cancel-pairing-button" stretch onPress={cancelPairActiveVault}>
+                  <ButtonSecondary testID="load-vault-cancel-pairing-button" accessibilityLabel="load-vault-cancel-pairing-button" stretch onPress={cancelPairActiveVault}>
                     {t`Cancel Pairing`}
                   </ButtonSecondary>
                 </>
@@ -104,6 +107,7 @@ export const LoadVault = () => {
                 <>
                   <ButtonPrimary
                     testID="load-vault-open-button"
+                    accessibilityLabel="load-vault-open-button"
                     onPress={() => pairWithCode(inviteCode)}
                     stretch
                     disabled={!inviteCode.length || isLoading}
@@ -113,6 +117,7 @@ export const LoadVault = () => {
 
                   <ButtonSecondary
                     testID="load-vault-select-vaults-button"
+                    accessibilityLabel="load-vault-select-vaults-button"
                     stretch
                     onPress={() =>
                       navigation.navigate('Welcome', { state: 'selectOrLoad' })

--- a/src/containers/Auth/NewVault.jsx
+++ b/src/containers/Auth/NewVault.jsx
@@ -96,6 +96,7 @@ export const NewVault = () => {
   return (
     <KeyboardAvoidingView
       testID="new-vault-screen"
+      accessibilityLabel="new-vault-screen"
       style={styles.flex}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}
@@ -114,15 +115,16 @@ export const NewVault = () => {
         >
           <View style={styles.formContainer}>
             <View style={styles.headerBlock}>
-              <Text style={styles.title}testID="new-vault-title">{t`Create New Vault`}</Text>
+              <Text style={styles.title} testID="new-vault-title" accessibilityLabel="new-vault-title">{t`Create New Vault`}</Text>
               <Text
-                style={styles.subtitle} testID="new-vault-subtitle"
+                style={styles.subtitle} testID="new-vault-subtitle" accessibilityLabel="new-vault-subtitle"
               >{t`Create your first vault by giving it a name. You can also add a password to secure this vault for extra protection.`}</Text>
             </View>
 
             <View style={styles.inputs}>
               <InputPasswordPearPass
                 testID="new-vault-name-input"
+                accessibilityLabel="new-vault-name-input"
                 placeholder={t`Enter Name`}
                 {...register('name')}
               />
@@ -147,6 +149,7 @@ export const NewVault = () => {
                   >
                     <ButtonLittle
                       testID="new-vault-toggle-password-section"
+                      accessibilityLabel="new-vault-toggle-password-section"
                       onPress={toggle}
                       variant="secondary"
                       borderRadius="lg"
@@ -164,6 +167,7 @@ export const NewVault = () => {
                 >
                   <InputPasswordPearPass
                     testID="new-vault-password-input"
+                    accessibilityLabel="new-vault-password-input"
                     placeholder={t`Enter Password`}
                     {...register('password')}
                     isPassword
@@ -173,6 +177,7 @@ export const NewVault = () => {
                     <Text style={styles.label}>{t`Repeat Vault password`}</Text>
                     <InputPasswordPearPass
                       testID="new-vault-confirm-password-input"
+                      accessibilityLabel="new-vault-confirm-password-input"
                       placeholder={t`Confirm Password`}
                       {...register('passwordConfirm')}
                       isPassword
@@ -185,22 +190,24 @@ export const NewVault = () => {
               {isLoading ? (
                 <ActivityIndicator
                   testID="new-vault-loading"
+                  accessibilityLabel="new-vault-loading"
                   size="small"
                   color={colors.primary400.mode1}
                 />
               ) : (
                 <>
-                  <ButtonPrimary testID="new-vault-continue-button" stretch onPress={handleSubmit(onSubmit)}>
-                    {t`Continue`}
+                  <ButtonPrimary testID="new-vault-continue-button" accessibilityLabel="new-vault-continue-button" stretch onPress={handleSubmit(onSubmit)}>
+                    <Text testID="new-vault-continue-text" accessibilityLabel="new-vault-continue-text">{t`Continue`}</Text>
                   </ButtonPrimary>
                   <ButtonSecondary
                     testID="new-vault-select-vaults-button"
+                    accessibilityLabel="new-vault-select-vaults-button"
                     stretch
                     onPress={() =>
                       navigation.navigate('Welcome', { state: 'selectOrLoad' })
                     }
                   >
-                    {t`Select Vaults`}
+                    <Text testID="new-vault-select-vaults-text" accessibilityLabel="new-vault-select-vaults-text">{t`Select Vaults`}</Text>
                   </ButtonSecondary>
                 </>
               )}

--- a/src/containers/Auth/SelectVaultType.jsx
+++ b/src/containers/Auth/SelectVaultType.jsx
@@ -30,7 +30,7 @@ export const SelectVaultType = () => {
   }
 
   return (
-    <View style={styles.container} testID="select-vault-type-logo">
+    <View style={styles.container} testID="select-vault-type-logo" accessibilityLabel="select-vault-type-logo">
       <View style={styles.logoContainer}>
         <LogoTextWithLock width={170} height={50} />
       </View>
@@ -38,19 +38,20 @@ export const SelectVaultType = () => {
       <View style={styles.topSection}>
         {!vaultsData?.length ? (
           <View style={styles.textWrapper}>
-            <Text style={styles.headerText} testID="select-vault-type-empty-title">{t`Enter Master Password`}</Text>
-            <Text style={styles.subHeaderText} testID="select-vault-type-empty-subtitle">
+            <Text style={styles.headerText} testID="select-vault-type-empty-title" accessibilityLabel="select-vault-type-empty-title">{t`Enter Master Password`}</Text>
+            <Text style={styles.subHeaderText} testID="select-vault-type-empty-subtitle" accessibilityLabel="select-vault-type-empty-subtitle">
               {t`Now create a secure vault or load an existing one to get started.`}
             </Text>
           </View>
         ) : (
-          <View style={styles.vaultsSection} testID="select-vault-type-vaults-section">
-            <Text style={styles.headerText} testID="select-vault-type-list-title">
+          <View style={styles.vaultsSection} testID="select-vault-type-vaults-section" accessibilityLabel="select-vault-type-vaults-section">
+            <Text style={styles.headerText} testID="select-vault-type-list-title" accessibilityLabel="select-vault-type-list-title">
               {t`Select a vault, create a new one or load another one`}
             </Text>
 
             <ScrollView
               testID="select-vault-type-vault-list"
+              accessibilityLabel="select-vault-type-vault-list"
               style={styles.vaultsList}
               showsVerticalScrollIndicator={false}
             >
@@ -58,6 +59,7 @@ export const SelectVaultType = () => {
                 <View key={vault.id} style={styles.vaultItemWrapper}>
                   <ListItem
                     testID={`select-vault-type-vault-item-${index}`}
+                    accessibilityLabel={`select-vault-type-vault-item-${index}`}
                     onPress={() => handleVaultSelect(vault.id)}
                     name={vault.name ?? vault.id}
                     date={vault.createdAt}
@@ -70,16 +72,17 @@ export const SelectVaultType = () => {
       </View>
 
       <View style={styles.bottomSection}>
-        <ButtonPrimary testID="select-vault-type-create-new" stretch onPress={handleCreateVault}>
-          {t`Create a new vault`}
+        <ButtonPrimary testID="select-vault-type-create-new" accessibilityLabel="select-vault-type-create-new" stretch onPress={handleCreateVault}>
+          <Text testID="select-vault-type-create-new-text" accessibilityLabel="select-vault-type-create-new-text">{t`Create a new vault`}</Text>
         </ButtonPrimary>
 
         <ButtonSecondary
           testID="select-vault-type-load-existing"
+          accessibilityLabel="select-vault-type-load-existing"
           stretch
           onPress={() => navigation.navigate('Welcome', { state: 'load' })}
         >
-          {t`Load a vault`}
+          <Text testID="select-vault-type-load-existing-text" accessibilityLabel="select-vault-type-load-existing-text">{t`Load a vault`}</Text>
         </ButtonSecondary>
       </View>
     </View>

--- a/src/containers/Auth/UnlockVault.jsx
+++ b/src/containers/Auth/UnlockVault.jsx
@@ -70,12 +70,14 @@ export const UnlockVault = ({ vaultId }) => {
   return (
     <KeyboardAvoidingView
       testID="unlock-vault-screen"
+      accessibilityLabel="unlock-vault-screen"
       style={{ flex: 1 }}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}
     >
       <ScrollView
         testID="unlock-vault-scroll"
+        accessibilityLabel="unlock-vault-scroll"
         contentContainerStyle={{
           flexGrow: 1,
           justifyContent: 'center',
@@ -88,6 +90,7 @@ export const UnlockVault = ({ vaultId }) => {
       >
         <View
           testID="unlock-vault-form-container"
+          accessibilityLabel="unlock-vault-form-container"
           style={{
             width: '100%',
             maxWidth: 400,
@@ -97,6 +100,7 @@ export const UnlockVault = ({ vaultId }) => {
         >
           <Text
             testID="unlock-vault-title"
+            accessibilityLabel="unlock-vault-title"
             style={{
               fontSize: 16,
               fontWeight: '500',
@@ -112,6 +116,7 @@ export const UnlockVault = ({ vaultId }) => {
           <View style={{ width: '100%' }}>
             <InputPasswordPearPass
               testID="unlock-vault-password-input"
+              accessibilityLabel="unlock-vault-password-input"
               placeholder={t`Vault password`}
               {...register('password')}
               isPassword
@@ -119,18 +124,20 @@ export const UnlockVault = ({ vaultId }) => {
           </View>
 
           <View
-            testID="unlock-vault-actions-container" 
+            testID="unlock-vault-actions-container"
+            accessibilityLabel="unlock-vault-actions-container"
             style={{ width: '100%', gap: 10 }}>
             {isLoading ? (
-              <ActivityIndicator testID="unlock-vault-loading" size="small" color={colors.primary400.mode1} />
+              <ActivityIndicator testID="unlock-vault-loading" accessibilityLabel="unlock-vault-loading" size="small" color={colors.primary400.mode1} />
             ) : (
               <>
-                <ButtonPrimary testID="unlock-vault-continue-button" stretch onPress={handleSubmit(onSubmit)}>
+                <ButtonPrimary testID="unlock-vault-continue-button" accessibilityLabel="unlock-vault-continue-button" stretch onPress={handleSubmit(onSubmit)}>
                   {t`Continue`}
                 </ButtonPrimary>
 
                 <ButtonSecondary
                   testID="unlock-vault-select-vaults-button"
+                  accessibilityLabel="unlock-vault-select-vaults-button"
                   stretch
                   onPress={() =>
                     navigation.navigate('Welcome', { state: 'selectOrLoad' })

--- a/src/containers/OnboardingContainer/index.jsx
+++ b/src/containers/OnboardingContainer/index.jsx
@@ -332,14 +332,14 @@ export const OnboardingContainer = ({
         testID="onboarding-continue-button"
         accessibilityLabel="onboarding-continue-button"
         onPress={onContinue} style={styles.continueButton}>
-          <Text testID="onboarding-continue-text" style={styles.continueButtonText}>{t`Continue`}</Text>
+          <Text testID="onboarding-continue-text" accessibilityLabel="onboarding-continue-text" style={styles.continueButtonText}>{t`Continue`}</Text>
         </TouchableOpacity>
         {currentStep !== SCREENS[SCREENS.length - 1] && (
           <TouchableOpacity 
           testID="onboarding-skip-button"
           accessibilityLabel="onboarding-skip-button"
           onPress={onSkip} style={styles.skipButton}>
-            <Text testID="onboarding-skip-text" style={styles.skipButtonText}>{t`Skip`}</Text>
+            <Text testID="onboarding-skip-text" accessibilityLabel="onboarding-skip-text" style={styles.skipButtonText}>{t`Skip`}</Text>
           </TouchableOpacity>
         )}
       </View>
@@ -387,17 +387,17 @@ export const OnboardingContainer = ({
         accessibilityLabel="onboarding-bottom-section"
         style={styles.bottomSection}>
           <Text 
-          testID="onboarding-main-description"
-          nativeID="onboarding-main-description"
-          accessibilityLabel="onboarding-main-description"
+          testID={`onboarding-main-description-${currentStep}`}
+          nativeID={`onboarding-main-description-${currentStep}`}
+          accessibilityLabel={`onboarding-main-description-${currentStep}`}
           style={styles.descriptionText}>{mainDescription}</Text>
 
           {getSubDescriptionContent() && (
             <View style={styles.subDescriptionWrapper}>
               <Text style={styles.subDescriptionText}
-                testID="onboarding-sub-description"
-                nativeID="onboarding-sub-description"
-                accessibilityLabel="onboarding-sub-description"
+                testID={`onboarding-sub-description-${currentStep}`}
+                nativeID={`onboarding-sub-description-${currentStep}`}
+                accessibilityLabel={`onboarding-sub-description-${currentStep}`}
               >
                 {getSubDescriptionContent()}
               </Text>


### PR DESCRIPTION
This PR adds and fixes `testID` / accessibility identifiers for SignUp and related onboarding/auth screens to improve E2E test stability and iOS visibility.

The changes follow the existing kebab-case naming convention used across the project and align with previous E2E setup.

- Added missing `testID` / `accessibilityLabel` for SignUp screens
- Fixed and aligned existing testIDs on onboarding/auth screens
- Ensured kebab-case naming consistency (Maestro / Appium friendly)
- Improved iOS accessibility visibility for E2E automation

- Verified changes locally
- IDs are visible in accessibility tree
- No functional UI changes

- This PR contains **UI-only changes** (`src` folder)
- E2E tests for SignUp will be added in a follow-up commit/PR
