### PR TITLE
Add text/comma-separated-values MIME type for CSV imports

### DIFF
--- a/src/screens/Settings/TabImport/utils/readFileContent.js
+++ b/src/screens/Settings/TabImport/utils/readFileContent.js
@@ -2,9 +2,15 @@ import * as DocumentPicker from 'expo-document-picker'
 import * as FileSystem from 'expo-file-system'
 
 export const readFileContent = async (acceptedTypes) => {
-  const type = acceptedTypes.map((type) =>
-    type === '.csv' ? 'text/csv' : type === '.json' ? 'application/json' : type
-  )
+  const type = acceptedTypes.flatMap((type) => {
+    if (type === '.csv') {
+      return ['text/csv', 'text/comma-separated-values']
+    } else if (type === '.json') {
+      return ['application/json']
+    } else {
+      return [type]
+    }
+  })
 
   const result = await DocumentPicker.getDocumentAsync({ type })
 


### PR DESCRIPTION
[Ticket ID](url)

### Requirements

We can't import .csv files on android right now.

### Changes

- Added text/comma-separated-values type to support csv on android

### Screenshots/Recordings


https://github.com/user-attachments/assets/f7d61eda-2b45-4630-be0b-948225730bd7


https://github.com/user-attachments/assets/92c1423e-d494-424e-bc26-8464aaf65abc

