### PR TITLE
Fixed The "Lock" screen is displayed when switching between the PearPass app and the third-party app

### DIFF
--- a/src/app/App/hooks/useAutoLock.js
+++ b/src/app/App/hooks/useAutoLock.js
@@ -49,6 +49,10 @@ export const useAutoLock = () => {
           navigation.navigate('Welcome', { state: 'enterMasterPassword' })
           resetState()
         }
+
+        if (previousAppState.match(/background/) && nextAppState === 'active') {
+          await refetchUser()
+        }
       }
     )
 


### PR DESCRIPTION
[Ticket ID](url)

### Requirements

The "Lock" screen is displayed when switching between the PearPass app and the third-party app.

`closeAllInstances()` on background cleared encryption without re-initializing on return, causing "Encryption not initialised" in the pearpass-lib-vault-core `getData()` error during biometric login.

### Changes

- Re-initialize encryption via refetchUser() when app returns from background 

### Screenshots/Recordings


https://github.com/user-attachments/assets/ae56d48d-a87c-4c9f-98cb-1e1b6b0940a7

