### PR TITLE
Removed refetchUser after returning from background

### DIFF
--- a/src/app/App/hooks/useAutoLock.js
+++ b/src/app/App/hooks/useAutoLock.js
@@ -52,10 +52,6 @@ export const useAutoLock = () => {
           })
           resetState()
         }
-
-        if (previousAppState.match(/background/) && nextAppState === 'active') {
-          await refetchUser()
-        }
       }
     )
 


### PR DESCRIPTION
When I log into the app and switch away from it very quickly, it sometimes gets locked.

The changes I removed were the ones I added yesterday to fix this exact same bug.