### PR TITLE
Add testID and accessibilityLabel to mobile app

### DIFF
--- a/src/containers/BottomSheetMasterPassword/BottomSheetMasterPassword.jsx
+++ b/src/containers/BottomSheetMasterPassword/BottomSheetMasterPassword.jsx
@@ -91,6 +91,7 @@ export const BottomSheetMasterPassword = ({ onClose, onConfirm }) => {
             placeholder={t`Insert Master password`}
             isPassword
             as={BottomSheetTextInput}
+            testID="export-vault-modal-password-input"
             {...register('password')}
           />
         </View>

--- a/src/containers/Modal/ModifyMasterVaultModalContent/index.jsx
+++ b/src/containers/Modal/ModifyMasterVaultModalContent/index.jsx
@@ -100,17 +100,32 @@ export const ModifyMasterVaultModalContent = () => {
     >
       <InputWrapper>
         <InputLabel>{t`Insert old password`}</InputLabel>
-        <InputPasswordPearPass isPassword {...register('currentPassword')} />
+        <InputPasswordPearPass
+          isPassword
+          {...register('currentPassword')}
+          testID="insert-old-password-input"
+          accessibilityLabel={t`Insert old password`}
+        />
       </InputWrapper>
 
       <InputWrapper>
         <InputLabel>{t`Create new password`}</InputLabel>
-        <InputPasswordPearPass isPassword {...register('newPassword')} />
+        <InputPasswordPearPass
+          isPassword
+          {...register('newPassword')}
+          testID="create-new-password-input"
+          accessibilityLabel={t`Create new password`}
+        />
       </InputWrapper>
 
       <InputWrapper>
         <InputLabel>{t`Repeat new password`}</InputLabel>
-        <InputPasswordPearPass isPassword {...register('repeatPassword')} />
+        <InputPasswordPearPass
+          isPassword
+          {...register('repeatPassword')}
+          testID="repeat-new-password-input"
+          accessibilityLabel={t`Repeat new password`}
+        />
       </InputWrapper>
     </ModifyVaultsModaContentWrapper>
   )

--- a/src/containers/Modal/ModifyVaultModalContent/index.jsx
+++ b/src/containers/Modal/ModifyVaultModalContent/index.jsx
@@ -138,7 +138,11 @@ export const ModifyVaultModalContent = ({
         <>
           <InputWrapper>
             <InputLabel>{t`Vault name`}</InputLabel>
-            <InputPasswordPearPass {...register('name')} />
+            <InputPasswordPearPass
+              {...register('name')}
+              testID="change-vault-name-input"
+              accessibilityLabel={t`Vault name`}
+            />
           </InputWrapper>
 
           {isProtected && (

--- a/src/screens/Settings/TabGeneralSettings/ReportSection/index.jsx
+++ b/src/screens/Settings/TabGeneralSettings/ReportSection/index.jsx
@@ -30,6 +30,8 @@ export const ReportSection = ({
           placeholder={t`Write your issue...`}
           value={message}
           onChange={(text) => setMessage(text)}
+          testID="report-problem-issue-input"
+          accessibilityLabel={t`Write your issue`}
         />
 
         {isLoading ? (


### PR DESCRIPTION
### Changes
<!-- Summarize the changes introduced in this PR -->

Added testID and accessibilityLabel props to input components for E2E testing support:                                                                                                   
  - ModifyMasterVaultModalContent: Added to old password, new password, and repeat password inputs                 
  - ReportSection: Added to issue textarea                                                                         
  - ModifyVaultModalContent: Added to vault name input                                                             
  - BottomSheetMasterPassword: Added to master password input for export modal 
  
### Testing Notes
<!-- How did you test it? -->
Android emulator / IOS simulator

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-20 at 15 53 50" src="https://github.com/user-attachments/assets/4e5c76e9-425e-4221-8373-6023e4f928a4" />
