### PR TITLE
Add testID and accessibilityLabel for toggle switches with separate l…

### DIFF
--- a/src/components/AppSwitch/AppSwitch.jsx
+++ b/src/components/AppSwitch/AppSwitch.jsx
@@ -23,7 +23,12 @@ export const AppSwitch = ({
   onChange,
   style,
   value,
-  testID
+  testID,
+  testIDOn,
+  testIDOff,
+  accessibilityLabel,
+  accessibilityLabelOn,
+  accessibilityLabelOff
 }) => {
   const progress = useSharedValue(value ? 1 : 0)
 
@@ -54,13 +59,18 @@ export const AppSwitch = ({
     return { transform: [{ translateX }] }
   })
 
+  const resolvedTestID = testID || (value ? testIDOn : testIDOff)
+  const resolvedAccessibilityLabel =
+    accessibilityLabel || (value ? accessibilityLabelOn : accessibilityLabelOff)
+
   return (
     <Pressable
       onPress={handlePress}
       disabled={disabled}
-      testID={testID}
+      testID={resolvedTestID}
       accessibilityRole="switch"
       accessibilityState={{ checked: value, disabled }}
+      accessibilityLabel={resolvedAccessibilityLabel}
     >
       <Animated.View
         style={[

--- a/src/containers/AutoLockSettings/index.jsx
+++ b/src/containers/AutoLockSettings/index.jsx
@@ -55,7 +55,14 @@ export const AutoLockSettings = () => {
     <View style={styles.container}>
       <View style={styles.settingRow}>
         <Text style={styles.settingLabel}>{t`Auto Log-out`}</Text>
-        <AppSwitch value={isAutoLockEnabled} onChange={handleToggleAutoLock} />
+        <AppSwitch
+          value={isAutoLockEnabled}
+          onChange={handleToggleAutoLock}
+          testIDOn="auto-logout-toggle-on"
+          testIDOff="auto-logout-toggle-off"
+          accessibilityLabelOn={t`Auto Log-out enabled`}
+          accessibilityLabelOff={t`Auto Log-out disabled`}
+        />
       </View>
       <Text style={styles.description}>
         {t`Automatically logs you out after you stop interacting with the app, based on the timeout you select.`}

--- a/src/containers/BottomSheetPassGeneratorContent/RuleSelector/index.jsx
+++ b/src/containers/BottomSheetPassGeneratorContent/RuleSelector/index.jsx
@@ -16,7 +16,11 @@ import { AppSwitch } from '../../../components/AppSwitch/AppSwitch'
  *    name: string,
  *    label: string,
  *    description: string,
- *    disabled: boolean
+ *    disabled: boolean,
+ *    testIDOn: string,
+ *    testIDOff: string,
+ *    accessibilityLabelOn: string,
+ *    accessibilityLabelOff: string
  *  }
  *  selectedRules: {[key: string]: any}
  *  setRules: ({[key: string]: any}) => void
@@ -71,6 +75,10 @@ export const RuleSelector = ({
               disabled={rule.disabled}
               value={selectedRules[rule.name] || isAllRuleSelected}
               onChange={() => handleSwitchToggle(rule.name)}
+              testIDOn={rule.testIDOn}
+              testIDOff={rule.testIDOff}
+              accessibilityLabelOn={rule.accessibilityLabelOn}
+              accessibilityLabelOff={rule.accessibilityLabelOff}
             />
           </View>
         </Wrapper>

--- a/src/screens/Settings/TabPrivacy/BlindPeeringSection.jsx
+++ b/src/screens/Settings/TabPrivacy/BlindPeeringSection.jsx
@@ -134,7 +134,11 @@ export const BlindPeeringSection = () => {
             {
               name: 'blindPeers',
               label: t`Private Connections`,
-              description: t`Sync your encrypted vault securely with blind peers to improve availability and consistency. Blind peers cannot read your data.`
+              description: t`Sync your encrypted vault securely with blind peers to improve availability and consistency. Blind peers cannot read your data.`,
+              testIDOn: 'blind-peering-toggle-on',
+              testIDOff: 'blind-peering-toggle-off',
+              accessibilityLabelOn: t`Blind Peering enabled`,
+              accessibilityLabelOff: t`Blind Peering disabled`
             }
           ]}
           selectedRules={blindPeersRules}

--- a/src/screens/Settings/TabPrivacy/PrivacySection.jsx
+++ b/src/screens/Settings/TabPrivacy/PrivacySection.jsx
@@ -30,12 +30,20 @@ export const PrivacySection = () => {
       {
         name: 'passwordChangeReminder',
         label: t`Reminders`,
-        description: t`Enable the reminders to change your passwords`
+        description: t`Enable the reminders to change your passwords`,
+        testIDOn: 'reminders-toggle-on',
+        testIDOff: 'reminders-toggle-off',
+        accessibilityLabelOn: t`Reminders enabled`,
+        accessibilityLabelOff: t`Reminders disabled`
       },
       {
         name: 'copyToClipboard',
         label: t`Copy to clipboard`,
-        description: t`When clicking a password you copy that into your clipboard`
+        description: t`When clicking a password you copy that into your clipboard`,
+        testIDOn: 'copy-to-clipboard-toggle-on',
+        testIDOff: 'copy-to-clipboard-toggle-off',
+        accessibilityLabelOn: t`Copy to clipboard enabled`,
+        accessibilityLabelOff: t`Copy to clipboard disabled`
       }
     ]
 
@@ -43,7 +51,11 @@ export const PrivacySection = () => {
       options.push({
         name: 'biometrics',
         label: t`Unlock with biometrics`,
-        description: t`Unlock PearPass using the biometrics on your device`
+        description: t`Unlock PearPass using the biometrics on your device`,
+        testIDOn: 'biometrics-toggle-on',
+        testIDOff: 'biometrics-toggle-off',
+        accessibilityLabelOn: t`Unlock with biometrics enabled`,
+        accessibilityLabelOff: t`Unlock with biometrics disabled`
       })
     }
 


### PR DESCRIPTION
### Changes
<!-- Summarize the changes introduced in this PR -->
  - Added support for separate testID and accessibilityLabel props for ON/OFF states in AppSwitch component        
  - Added state-aware testIDs to all toggles in Settings > Advanced tab for E2E testing                           
                                                                                              
### Testing Notes
<!-- How did you test it? -->
Android emulator/ IOS
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-20 at 17 04 36" src="https://github.com/user-attachments/assets/6fb87c39-a663-4ccb-ad2a-e26d939648df" />
 simulator
