### PR TITLE
Clean prebuild in GH workflows

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Generate worklet bundle for Android
         run: npm run bundle:android
 
+      - name: Generate worklet bundle for Autofill
+        run: npm run bundle:autofill
+
       - name: Install EAS CLI
         run: npm install --global eas-cli
 
@@ -275,8 +278,8 @@ jobs:
       - name: Generate worklet bundle for iOS
         run: npm run bundle:ios
   
-      - name: Generate worklet bundle for iOS extension
-        run: npm run bundle:ios-extension
+      - name: Generate worklet bundle for Autofill
+        run: npm run bundle:autofill
 
       - name: Extract translations
         run: |


### PR DESCRIPTION
### Requirements
Update expo prebuild commands to include --clean option for both Android and iOS builds