### PR TITLE
Fix known autofill issues

### DIFF
--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CredentialsListFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CredentialsListFragment.java
@@ -162,13 +162,8 @@ public class CredentialsListFragment extends BaseAutofillFragment {
                 }
             }
 
-            // If we have matching credentials, show only those; otherwise show all
-            if (!matchingCredentials.isEmpty()) {
-                filtered = matchingCredentials;
-                SecureLog.d(TAG, "Filtered to " + matchingCredentials.size() + " credentials matching domain/package");
-            } else {
-                SecureLog.d(TAG, "No matching credentials found, showing all " + allCredentials.size() + " credentials");
-            }
+            filtered = matchingCredentials;
+            SecureLog.d(TAG, "Filtered to " + matchingCredentials.size() + " credentials matching domain/package");
         }
         // If hasUserSearched is true and query is empty, show all credentials (no filtering)
 
@@ -323,12 +318,19 @@ public class CredentialsListFragment extends BaseAutofillFragment {
                 recordData = record;
             }
 
+            // Skip folder records - they have "folder" field but no "title"/"type"
+            if (recordData.containsKey("folder") && !recordData.containsKey("title") && !recordData.containsKey("type")) {
+                SecureLog.d(TAG, "Skipping folder record: " + id);
+                continue;
+            }
+
             String name = (String) recordData.get("title");
             if (name == null) {
                 name = (String) recordData.get("name");
             }
-            if (name == null) {
-                name = "Unknown";
+            if (name == null || name.isEmpty()) {
+                SecureLog.d(TAG, "Skipping record without valid title/name: " + id);
+                continue;
             }
 
             String username = (String) recordData.get("username");

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/CredentialsListView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/CredentialsListView.swift
@@ -30,13 +30,8 @@ struct CredentialsListView: View {
             }
         } else if !hasUserSearched && !serviceIdentifiers.isEmpty {
             // Only apply domain filtering if user hasn't searched yet
-            let matchingCredentials = credentials.filter { credential in
+            filtered = credentials.filter { credential in
                 matchesServiceIdentifiers(credential: credential)
-            }
-
-            // If we have matching credentials, show only those; otherwise show all
-            if !matchingCredentials.isEmpty {
-                filtered = matchingCredentials
             }
         }
         // If hasUserSearched is true and searchText is empty, show all credentials (no filtering)
@@ -342,8 +337,20 @@ struct CredentialsListView: View {
                 // Don't continue - also parse as password credential if it has username/password
             }
 
+            // Skip folder records - they have no title and no type
+            if recordData.title.isEmpty && recordData.websites.isEmpty && recordData.username.isEmpty && recordData.password.isEmpty {
+                print("CredentialsListView: Skipping folder/empty record: \(record.id)")
+                continue
+            }
+
+            // Skip records without title
+            guard !recordData.title.isEmpty else {
+                print("CredentialsListView: Skipping record without title: \(record.id)")
+                continue
+            }
+
             // Also parse as a password credential
-            let name = recordData.title.isEmpty ? "Unknown" : recordData.title
+            let name = recordData.title
             let username = recordData.username
             let password = recordData.password
             let websites = recordData.websites

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/MasterPasswordView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/MasterPasswordView.swift
@@ -203,9 +203,7 @@ struct MasterPasswordView: View {
             } catch {
                 await MainActor.run {
                     isLoading = false
-                    errorMessage = error.localizedDescription.isEmpty ?
-                        NSLocalizedString("Invalid password", comment: "Invalid password error") :
-                        error.localizedDescription
+                    errorMessage = NSLocalizedString("Invalid master password", comment: "Invalid master password error")
                 }
             }
         }


### PR DESCRIPTION
### Changes
<!-- Summarize the changes introduced in this PR -->
   Fix iOS & Android autofill issues :
   
   filter out folder records that appeared as "Unknown" in credentials list                          
   show empty list when no credentials match the current website/app, instead of showing all credentials
   always show "Invalid master password" error message instead of raw error descriptions                       
 

### Testing Notes
<!-- How did you test it? -->
Android emulator & IOS simulator
### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

https://github.com/user-attachments/assets/e725f9bf-d23e-4a28-a5b4-2360ae07e6e7

https://github.com/user-attachments/assets/a51344f6-85bc-4ace-9e97-6ee8bc529ccc



