### PR TITLE
The blind peering tool-tips' text does not correspond to the figma design

### DIFF
--- a/src/containers/BottomSheetBlindPeeringTooltip/index.jsx
+++ b/src/containers/BottomSheetBlindPeeringTooltip/index.jsx
@@ -47,7 +47,10 @@ export const BottomSheetBlindPeeringTooltip = () => {
         <Text style={styles.description}>
           {t`• `}
           <Text style={styles.boldText}>{t`Manual Blind Peers: `}</Text>
-          {t`Setup your own private Blind Peers.In both cases, all data stays fully encrypted, ensuring safe, non-intrusive replication and better data consistency`}
+          {t`Setup your own private Blind Peers.`}
+        </Text>
+        <Text style={styles.description}>
+          {t`In both cases, all data stays fully encrypted, ensuring safe, non-intrusive replication and better data consistency.`}
         </Text>
       </View>
       <View style={{ alignSelf: 'center' }}>


### PR DESCRIPTION
### Changes
<!-- Summarize the changes introduced in this PR -->                                                                                                                
  - Separated "In both cases..." sentence into its own paragraph in the Blind Peer tooltip                           
  - Added missing period at the end of the sentence
### Testing Notes
<!-- How did you test it? -->
IOS simulator
### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-05 at 16 45 43" src="https://github.com/user-attachments/assets/7d18de93-a956-4c87-b66c-0a48ab75b6d9" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213133076779302
  - https://app.asana.com/0/0/1213046851514513