### PR TITLE
Fix app crash on long press in the folders drop down

### DIFF
--- a/src/containers/FolderList/index.jsx
+++ b/src/containers/FolderList/index.jsx
@@ -90,7 +90,7 @@ export const FolderList = ({
         <Folder
           key={folder.name}
           onFolderSelect={(folder) => onFolderSelect(folder)}
-          onLongPress={() => onLongPress(folder.name)}
+          onLongPress={() => onLongPress?.(folder.name)}
           onCreateNewFolder={handleCreateNewFolder}
           folder={folder}
           isLast={index === filteredFolderList.length - 1}


### PR DESCRIPTION
### Requirements

The app crashes when a user creates a new folder on the "Create an item" screen and then taps and holds it

### Changes

We did not provide onLongPress function in all cases, that's why it crashed, fixed it.

### Screenshots/Recordings


https://github.com/user-attachments/assets/fffd1747-e1fa-4539-97c0-6a64664f4a52




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213112595758497