### PR TITLE
Fixed passkey login items to not be case sensitive

### DIFF
--- a/plugins/expo-autofill-plugin/android-template/java/autofill/data/PearPassVaultClient.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/data/PearPassVaultClient.java
@@ -1893,7 +1893,7 @@ public class PearPassVaultClient {
                 String passkeyUsername = username != null ? username.trim() : "";
 
                 boolean usernameMatches = !passkeyUsername.isEmpty() && !recordUsername.isEmpty()
-                        && passkeyUsername.equals(recordUsername);
+                        && passkeyUsername.equalsIgnoreCase(recordUsername);
                 boolean hasNoUsername = recordUsername.isEmpty();
 
                 if (usernameMatches || hasNoUsername) {

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PearPassVaultClient.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PearPassVaultClient.swift
@@ -1214,7 +1214,7 @@ import Foundation
             let recordUsername = data.username.trimmingCharacters(in: .whitespaces)
             let passkeyUsername = username.trimmingCharacters(in: .whitespaces)
 
-            let usernameMatches = !passkeyUsername.isEmpty && !recordUsername.isEmpty && passkeyUsername == recordUsername
+            let usernameMatches = !passkeyUsername.isEmpty && !recordUsername.isEmpty && passkeyUsername.caseInsensitiveCompare(recordUsername) == .orderedSame
             let hasNoUsername = recordUsername.isEmpty
 
             if usernameMatches || hasNoUsername {


### PR DESCRIPTION
### Requirements

Login items with the username/email casing different from the website username/email casing are not displayed in the Passkey list

### Changes

Fixed passkey login items to not be case sensitive

### Testing Notes
<!-- How did you test it? -->

### Things reviewers should pay attention to
<!-- Highlight anything specific you want reviewers to focus on -->

### Screenshots/Recordings

Android:

https://github.com/user-attachments/assets/bce714fc-a6bb-4edf-876c-0586e03e1638


IOS:


https://github.com/user-attachments/assets/17682b22-ee9a-44f8-91b8-937a8b2cd831



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213148363752737