### PR TITLE
Implement screen when there are no results after item searching

### DIFF
--- a/src/containers/EmptyResultsView/index.jsx
+++ b/src/containers/EmptyResultsView/index.jsx
@@ -1,6 +1,6 @@
 import { useLingui } from '@lingui/react/macro'
 
-import { Container, SubTitle, Title } from './styles'
+import { Container, Title } from './styles'
 
 export const EmptyResultsView = () => {
   const { t } = useLingui()
@@ -8,8 +8,6 @@ export const EmptyResultsView = () => {
   return (
     <Container>
       <Title>{t`No result found.`}</Title>
-
-      <SubTitle>{t`Try to search it into another collection`}</SubTitle>
     </Container>
   )
 }

--- a/src/containers/EmptyResultsView/styles.js
+++ b/src/containers/EmptyResultsView/styles.js
@@ -6,7 +6,6 @@ export const Container = styled.View`
   gap: 20px;
   align-items: center;
   align-self: center;
-  gap: 5px;
 `
 
 export const Title = styled.Text`
@@ -15,12 +14,4 @@ export const Title = styled.Text`
   font-family: 'Inter';
   font-size: 16px;
   font-weight: 600;
-`
-
-export const SubTitle = styled.Text`
-  color: ${({ theme }) => theme.colors.white.mode1};
-  text-align: center;
-  font-family: 'Inter';
-  font-size: 14px;
-  font-weight: 400;
 `


### PR DESCRIPTION
### Changes
<!-- Summarize the changes introduced in this PR -->
Removed the "Try to search it into another collection" subtitle from the EmptyResultsView component.  
### Testing Notes
<!-- How did you test it? -->
Ios simulator 

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-06 at 16 48 23" src="https://github.com/user-attachments/assets/b46d4d1b-6975-4fcf-bd6e-b88148390e18" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212855376358182