### PR TITLE
Update GitHub Actions runner image to default to Xcode 26.2.

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -219,9 +219,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
           scope: "@tetherto"
       - name: Select Xcode 26
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '26'
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
       - name: Install Apple WWDRC Authority
         run: |


### PR DESCRIPTION
### Changes

- Update GitHub Actions runnner image to macos-26 which defaults to XCode 26 which makes EAS use iOS SDK 26 for build.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212975592679272