### PR TITLE
Improve regex escaping in copyAndProcessSourceFiles

### DIFF
--- a/plugins/expo-autofill-plugin/src/utils.ts
+++ b/plugins/expo-autofill-plugin/src/utils.ts
@@ -42,7 +42,7 @@ export async function copyAndProcessSourceFiles(
       let content = await fs.promises.readFile(srcPath, 'utf-8');
 
       for (const templatePackage of templatePackages) {
-        const escapeRegex = (s: string) => s.replace(/\./g, '\\.');
+        const escapeRegex = (s: string) => s.replace(/[\\.*+?^${}()|[\]]/g, '\\$&');
         const templateEscaped = escapeRegex(templatePackage);
 
         // Replace package declarations


### PR DESCRIPTION
### Changes
Improve regex escaping in copyAndProcessSourceFiles function for better handling of special characters in template package names.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213303070989171