### PR TITLE
Added bypass of auto lock on pairing

### DIFF
--- a/src/containers/Auth/LoadVault.jsx
+++ b/src/containers/Auth/LoadVault.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { useLingui } from '@lingui/react/macro'
 import { useNavigation } from '@react-navigation/native'
@@ -16,6 +16,7 @@ import {
   StyleSheet
 } from 'react-native'
 
+import { useAutoLockContext } from '../../context/AutoLockContext'
 import { useBottomSheet } from '../../context/BottomSheetContext'
 import { useKeyboardVisibility } from '../../hooks/useKeyboardVisibility'
 import {
@@ -39,6 +40,12 @@ export const LoadVault = () => {
 
   const { refetch: refetchVault, addDevice } = useVault()
   const { pairActiveVault, cancelPairActiveVault, isLoading } = usePair()
+  const { setShouldBypassAutoLock } = useAutoLockContext()
+
+  useEffect(() => {
+    setShouldBypassAutoLock(isLoading)
+    return () => setShouldBypassAutoLock(false)
+  }, [isLoading])
 
   const pairWithCode = async (code) => {
     try {

--- a/src/containers/BottomSheetAddDeviceContent/index.jsx
+++ b/src/containers/BottomSheetAddDeviceContent/index.jsx
@@ -12,13 +12,14 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { PairAnotherDeviceContent } from './PairAnotherDeviceContent'
 import { PairThisDeviceContent } from './PairThisDeviceContent'
 import { useBottomSheet } from '../../context/BottomSheetContext'
+import { withAutoLockBypass } from '../../HOCs'
 
 const TAB = {
   PAIR_THIS: 'pairThis',
   PAIR_ANOTHER: 'pairAnother'
 }
 
-export const BottomSheetAddDeviceContent = () => {
+const BottomSheetAddDeviceContentBase = () => {
   const { t } = useLingui()
   const { collapse } = useBottomSheet()
 
@@ -116,6 +117,10 @@ export const BottomSheetAddDeviceContent = () => {
     </BottomSheetScrollView>
   )
 }
+
+export const BottomSheetAddDeviceContent = withAutoLockBypass(
+  BottomSheetAddDeviceContentBase
+)
 
 const styles = StyleSheet.create({
   container: {

--- a/src/containers/BottomSheetQrScannerContent/index.jsx
+++ b/src/containers/BottomSheetQrScannerContent/index.jsx
@@ -19,6 +19,11 @@ export const BottomSheetQrScannerContent = ({ onScanned }) => {
   const { t } = useLingui()
   const { setShouldBypassAutoLock } = useAutoLockContext()
 
+  useEffect(() => {
+    setShouldBypassAutoLock(true)
+    return () => setShouldBypassAutoLock(false)
+  }, [])
+
   const {
     hasPermission,
     isScanning,
@@ -37,12 +42,7 @@ export const BottomSheetQrScannerContent = ({ onScanned }) => {
   })
 
   const handleRequestPermission = async () => {
-    setShouldBypassAutoLock(true)
-    try {
-      await requestPermission()
-    } finally {
-      setShouldBypassAutoLock(false)
-    }
+    await requestPermission()
   }
 
   useEffect(() => {
@@ -89,12 +89,7 @@ export const BottomSheetQrScannerContent = ({ onScanned }) => {
             </CameraView>
             <ButtonSecondary
               onPress={async () => {
-                setShouldBypassAutoLock(true)
-                try {
-                  await pickImageForScan()
-                } finally {
-                  setShouldBypassAutoLock(false)
-                }
+                await pickImageForScan()
               }}
               stretch
             >


### PR DESCRIPTION
### Requirements

- Auto-logout does not work when the Vault sharing process is currently in progress. But the logout timer still applies to this screen when the Vault is not being shared to avoid putting user data at risk
- Auto-logout does not work while the "Add device" pop-up is opened. It concerns both tabs:
Share this Vault
Import vault

### Changes

- Added bypass logic for pairing

### Screenshots/Recordings

https://github.com/user-attachments/assets/eb514e7f-2614-4c97-b5c7-30d58bca9a0f

https://github.com/user-attachments/assets/2c98bbb9-c120-45b7-b052-cfad53d38ccf



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213303828290749
  - https://app.asana.com/0/0/1213303828290761