### PR TITLE
Login items with empty "Website" and "Email/Username" fields are dispayed in the list of items available for saving a passkey && The user is taken to the passkey creation screen if there are no suitable login items in the vault (#181)

### DIFF
--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/PasskeyRegistrationActivity.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/PasskeyRegistrationActivity.java
@@ -391,15 +391,8 @@ public class PasskeyRegistrationActivity extends AppCompatActivity implements Na
 
                 runOnUiThread(() -> {
                     preloadedFolders = folders;
-
-                    if (matches.isEmpty()) {
-                        // No matches, go directly to form
-                        selectedExistingRecord = null;
-                        navigateToPasskeyForm();
-                    } else {
-                        // Show existing credential selection
-                        navigateToExistingCredentialSelection(matches);
-                    }
+                    // Always show selection screen so user can search or create new
+                    navigateToExistingCredentialSelection(matches);
                 });
             } catch (Exception e) {
                 SecureLog.e(TAG, "Error searching credentials: " + e.getMessage());

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PasskeyRegistrationView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PasskeyRegistrationView.swift
@@ -294,14 +294,8 @@ struct PasskeyRegistrationView: View {
                 await MainActor.run {
                     self.loadedFolders = folders
                     self.matchingRecords = matches
-                    if matches.isEmpty {
-                        // No matches — go directly to form
-                        self.selectedExistingRecord = nil
-                        self.currentStep = .editingForm
-                    } else {
-                        // Show selection screen
-                        self.currentStep = .selectingExisting
-                    }
+                    // Always show selection screen so user can search or create new
+                    self.currentStep = .selectingExisting
                 }
             } catch {
                 await MainActor.run {

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PearPassVaultClient.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PearPassVaultClient.swift
@@ -1199,8 +1199,9 @@ import Foundation
 
     // MARK: - Record Search Methods
 
-    /// Search for login records matching an rpId and username
-    /// Mirrors web extension logic: returns records where username matches OR record has no username
+    /// Search for login records matching an rpId and/or username
+    /// Returns records where website matches OR username matches
+    /// Records with BOTH empty website AND empty username are excluded
     func searchLoginRecords(rpId: String, username: String) async throws -> [VaultRecord] {
         log("Searching login records for rpId: \(rpId), username: \(username)")
 
@@ -1213,11 +1214,23 @@ import Foundation
 
             let recordUsername = data.username.trimmingCharacters(in: .whitespaces)
             let passkeyUsername = username.trimmingCharacters(in: .whitespaces)
+            let recordWebsites = data.websites
 
+            // Check if any website matches the rpId
+            let websiteMatches = recordWebsites.contains { normalizedDomainMatch($0, rpId) }
+
+            // Check if username matches (both must be non-empty)
             let usernameMatches = !passkeyUsername.isEmpty && !recordUsername.isEmpty && passkeyUsername.caseInsensitiveCompare(recordUsername) == .orderedSame
-            let hasNoUsername = recordUsername.isEmpty
 
-            if usernameMatches || hasNoUsername {
+            // Skip records with both empty website and empty username
+            let hasNoWebsites = recordWebsites.isEmpty || recordWebsites.allSatisfy { $0.trimmingCharacters(in: .whitespaces).isEmpty }
+            let hasNoUsername = recordUsername.isEmpty
+            if hasNoWebsites && hasNoUsername {
+                continue
+            }
+
+            // Include if website matches OR username matches
+            if websiteMatches || usernameMatches {
                 matches.append(record)
             }
         }


### PR DESCRIPTION
Cherry pick https://github.com/tetherto/pearpass-app-mobile/pull/181
