### PR TITLE
Login items with empty "Website" and "Email/Username" fields are displayed in the list of items available for saving a passkey

### DIFF
--- a/plugins/expo-autofill-plugin/android-template/java/autofill/data/PearPassVaultClient.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/data/PearPassVaultClient.java
@@ -1925,8 +1925,8 @@ public class PearPassVaultClient {
                     continue;
                 }
 
-                // Include if website matches OR username matches
-                if (websiteMatches || usernameMatches) {
+                // Include only if BOTH website AND username match
+                if (websiteMatches && usernameMatches) {
                     matches.add(record);
                 }
             }

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PearPassVaultClient.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PearPassVaultClient.swift
@@ -1199,8 +1199,8 @@ import Foundation
 
     // MARK: - Record Search Methods
 
-    /// Search for login records matching an rpId and/or username
-    /// Returns records where website matches OR username matches
+    /// Search for login records matching an rpId AND username
+    /// Returns records where BOTH website AND username match
     /// Records with BOTH empty website AND empty username are excluded
     func searchLoginRecords(rpId: String, username: String) async throws -> [VaultRecord] {
         log("Searching login records for rpId: \(rpId), username: \(username)")
@@ -1229,8 +1229,8 @@ import Foundation
                 continue
             }
 
-            // Include if website matches OR username matches
-            if websiteMatches || usernameMatches {
+            // Include only if BOTH website AND username match
+            if websiteMatches && usernameMatches {
                 matches.append(record)
             }
         }


### PR DESCRIPTION
### Changes
<!-- Summarize the changes introduced in this PR -->
When saving a passkey, login items are now displayed only if both website and  username match the passkey request        
(previously, items were shown if either field matched). 

### Testing Notes
<!-- How did you test it? -->
Android Emulator & IOS simulator

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

https://github.com/user-attachments/assets/5ebc84df-ae8e-4d6c-9010-aee533b2202f

https://github.com/user-attachments/assets/b928c36e-99d3-4f68-9e51-1f9eda5a2c2d

