### PR TITLE
he user is taken to the passkey creation screen if there are no suita…

### DIFF
--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/ExistingCredentialSelectionView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/ExistingCredentialSelectionView.swift
@@ -89,20 +89,23 @@ struct ExistingCredentialSelectionView: View {
 
                     // Existing credentials list or empty state
                     if filteredRecords.isEmpty {
-                        Spacer().frame(height: 80)
-                        HStack {
-                            Spacer()
-                            Text(NSLocalizedString("No matching login found, search it or create a new login to store this passkey.", comment: "Empty state message"))
-                                .font(.system(size: 14))
-                                .foregroundColor(.white.opacity(0.7))
-                                .multilineTextAlignment(.center)
-                                .padding(.horizontal, 20)
-                                .padding(.vertical, 16)
-                                .background(
-                                    RoundedRectangle(cornerRadius: Constants.Layout.smallCornerRadius)
-                                        .fill(Color(red: 0x30/255, green: 0x30/255, blue: 0x30/255))
-                                )
-                            Spacer()
+                        // Only show empty state message when user has searched (not on initial empty state)
+                        if !searchText.trimmingCharacters(in: .whitespaces).isEmpty {
+                            Spacer().frame(height: 80)
+                            HStack {
+                                Spacer()
+                                Text(NSLocalizedString("No matching login found, search it or create a new login to store this passkey.", comment: "Empty state message"))
+                                    .font(.system(size: 14))
+                                    .foregroundColor(.white.opacity(0.7))
+                                    .multilineTextAlignment(.center)
+                                    .padding(.horizontal, 20)
+                                    .padding(.vertical, 16)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: Constants.Layout.smallCornerRadius)
+                                            .fill(Color(red: 0x30/255, green: 0x30/255, blue: 0x30/255))
+                                    )
+                                Spacer()
+                            }
                         }
                     } else {
                         VStack(spacing: 0) {


### PR DESCRIPTION
### Changes
<!-- Summarize the changes introduced in this PR -->
Removed the "No matching login found..." message on iOS when the list is initially empty. Now this message only appears when the user searches and finds no results. 

### Testing Notes
<!-- How did you test it? -->
IOS Simulator

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->
https://github.com/user-attachments/assets/4affeb9f-b3fe-4a0a-9f6b-b38991d4c69c

