### PR TITLE
feat: android ABI split during gradlew build

### DIFF
--- a/docs/fdroid/build.md
+++ b/docs/fdroid/build.md
@@ -48,12 +48,14 @@ npm run fdroid:patches:build
 cd android
 ANDROID_HOME=$HOME/Library/Android/sdk \
   GRADLE_USER_HOME=/tmp/pearpass-gradle-home \
-  ./gradlew :app:assembleFdroidRelease --no-daemon -Dorg.gradle.vfs.watch=false
+  ./gradlew :app:assembleFdroidRelease --no-daemon -Dorg.gradle.vfs.watch=false \
+    -Ppearpass.enableAbiSplits=true \
+    -Ppearpass.abis=arm64-v8a,armeabi-v7a
 ```
 
-Expected output path (Gradle default):
+Expected output path (ABI split):
 
-- `android/app/build/outputs/apk/fdroid/release/app-fdroid-release.apk`
+- `android/app/build/outputs/apk/fdroid/release/app-fdroid-*-release.apk`
 
 ## Feature differences (current)
 

--- a/scripts/fdroid-build.sh
+++ b/scripts/fdroid-build.sh
@@ -186,7 +186,7 @@ run_build() {
     printf 'android.enableDependencyInfoInBundle=false\n' >> gradle.properties
   fi
   ensure_java_home
-  JAVA_HOME="$JAVA_HOME" GRADLE_USER_HOME=/tmp/pearpass-gradle-home ./gradlew :app:clean :app:assembleRelease --no-daemon -Dorg.gradle.vfs.watch=false -Dorg.gradle.java.installations.auto-download=false -Dorg.gradle.java.installations.auto-detect=false -Dorg.gradle.java.installations.paths="$JAVA_HOME" -Pandroid.enableDependencyInfoInApk=false -Pandroid.enableDependencyInfoInBundle=false
+  JAVA_HOME="$JAVA_HOME" GRADLE_USER_HOME=/tmp/pearpass-gradle-home ./gradlew :app:clean :app:assembleFdroidRelease --no-daemon -Dorg.gradle.vfs.watch=false -Dorg.gradle.java.installations.auto-download=false -Dorg.gradle.java.installations.auto-detect=false -Dorg.gradle.java.installations.paths="$JAVA_HOME" -Pandroid.enableDependencyInfoInApk=false -Pandroid.enableDependencyInfoInBundle=false -Ppearpass.enableAbiSplits=true -Ppearpass.abis=arm64-v8a,armeabi-v7a
 }
 
 case "$phase" in


### PR DESCRIPTION
### Requirements
- Reduce the size and build footprint of the F-Droid Android release flow.
- Ensure the F-Droid path builds only the fdroid flavor instead of the generic release task.
- Generate ABI-specific APKs for supported device architectures instead of a single universal output.
- Keep the local F-Droid build instructions aligned with the actual build behavior.
### Changes
- Updated the F-Droid Android build flow to use :app:assembleFdroidRelease .
- Enabled ABI split support for the F-Droid build path and limited it to arm64-v8a and armeabi-v7a .
- Updated the local F-Droid build documentation to reflect the ABI split flags and the new output pattern.
- Kept the F-Droid-specific Gradle flags focused on reducing unnecessary release build overhead.
### Testing Notes
- Reviewed local native build outputs and confirmed that libreactnative.so is stripped correctly in the packaging stage, while libbare-kit.so remains large even when stripped.
- Verified the updated F-Droid build command and expected output path in the docs.
- Validated the edited build-related files for obvious syntax/config issues.
### Things reviewers should pay attention to
- Whether ABI splits should stay limited to arm64-v8a and armeabi-v7a for the F-Droid distribution.
- Whether switching from assembleRelease to assembleFdroidRelease affects any downstream assumptions in CI.
- Whether the expected APK output pattern matches what the F-Droid pipeline consumes.
### Screenshots/Recordings
- Not applicable.
### dependencies
- Any corresponding fdroiddata update must expect ABI-split APK outputs instead of a single universal release APK.
