### PR TITLE
fix: fixing andoird camera issue

### DIFF
--- a/scripts/fdroid-build.sh
+++ b/scripts/fdroid-build.sh
@@ -27,56 +27,9 @@ module.exports = class SwarmConfig {
 EOF
 }
 
-write_expo_camera_stub() {
-  rm -rf node_modules/expo-camera
-  mkdir -p node_modules/expo-camera
-  cat > node_modules/expo-camera/package.json <<'EOF'
-{
-  "name": "expo-camera",
-  "version": "16.1.11-fdroid",
-  "main": "index.js",
-  "expo": {
-    "plugin": "./app.plugin.js"
-  }
-}
-EOF
-  cat > node_modules/expo-camera/app.plugin.js <<'EOF'
-module.exports = (config) => config
-EOF
-  cat > node_modules/expo-camera/index.js <<'EOF'
-const PermissionStatus = {
-  GRANTED: "granted",
-  DENIED: "denied"
-}
-
-const Camera = {
-  async getCameraPermissionsAsync() {
-    return { status: PermissionStatus.DENIED }
-  },
-  async requestCameraPermissionsAsync() {
-    return { status: PermissionStatus.DENIED, canAskAgain: false }
-  },
-  async scanFromURLAsync() {
-    return []
-  }
-}
-
-function CameraView() {
-  return null
-}
-
-module.exports = {
-  Camera,
-  CameraView,
-  PermissionStatus
-}
-EOF
-}
-
 run_prebuild() {
   npm ci --install-links --legacy-peer-deps --no-audit --no-fund
   write_swarmconf_stub
-  write_expo_camera_stub
   npm run fdroid:patches:prebuild
   npm run build
   ./node_modules/.bin/expo prebuild --platform android --clean --no-install
@@ -168,10 +121,10 @@ run_build() {
   rm -f app/google-services.json
   perl -i -ne "print unless /com\\.google\\.gms\\.google-services/" app/build.gradle build.gradle
   if ! grep -q "fdroid-root-excludes" build.gradle; then
-    printf '\n// fdroid-root-excludes\nsubprojects {\n  configurations.all {\n    exclude group: "com.google.firebase"\n    exclude group: "com.google.firebase", module: "firebase-messaging"\n  }\n}\n' >> build.gradle
+    printf '\n// fdroid-root-excludes\nsubprojects {\n  configurations.all {\n    exclude group: "com.google.firebase", module: "firebase-messaging"\n  }\n}\n' >> build.gradle
   fi
   if ! grep -q "fdroid-global-excludes" app/build.gradle; then
-    printf '\n// fdroid-global-excludes\nconfigurations.all {\n  exclude group: "com.google.firebase"\n  exclude group: "com.google.firebase", module: "firebase-messaging"\n  exclude group: "com.google.android.gms", module: "play-services-fido"\n  exclude group: "com.google.android.gms", module: "play-services-auth"\n  exclude group: "androidx.credentials", module: "credentials-play-services-auth"\n}\n' >> app/build.gradle
+    printf '\n// fdroid-global-excludes\nconfigurations.all {\n  exclude group: "com.google.firebase", module: "firebase-messaging"\n  exclude group: "com.google.android.gms", module: "play-services-fido"\n  exclude group: "com.google.android.gms", module: "play-services-auth"\n  exclude group: "androidx.credentials", module: "credentials-play-services-auth"\n}\n' >> app/build.gradle
   fi
   if ! grep -q "dependenciesInfo {" app/build.gradle; then
     perl -0777 -i -pe "s/android\\s*\\{\\n/android {\\n    dependenciesInfo {\\n        includeInApk = false\\n        includeInBundle = false\\n    }\\n/s" app/build.gradle


### PR DESCRIPTION
### Requirements
- Fix the F-Droid-specific camera regression in PearPass.
- Ensure the QR scanner in the vault import / "Add Device" flow can use the real Android camera implementation in F-Droid builds.
- Ensure the app correctly recognizes already-granted camera permission on Android in F-Droid builds.
- Avoid requiring repeated upstream/F-Droid metadata iteration just to validate the fix.
### Changes
- Removed the F-Droid expo-camera stub from scripts/fdroid-build.sh so F-Droid builds use the real expo-camera package instead of a fake implementation that always returned denied permission and a null camera view.
- Updated the QR scanner permission handling in src/hooks/useQRScanner.js to better support F-Droid Android behavior by:
  - checking native Android camera permission state
  - re-syncing permission state when the app returns to foreground from system settings
  - avoiding false negatives when Expo permission state is stale on F-Droid builds
- Added/updated tests in src/hooks/useQRScanner.test.js covering the F-Droid Android permission-sync scenario.
- Validated the F-Droid build flow locally against a fork/current branch to confirm the APK can be rebuilt with the fix.
### Testing Notes
- Ran focused hook tests for useQRScanner .
- Built a local F-Droid APK using fdroidserver .
- Installed the generated APK on Android/emulator and reproduced the startup/build-specific issues during validation.
- Confirmed the original F-Droid breakage source was the camera stub in fdroid-build.sh .
- Confirmed the local F-Droid build can complete after metadata/build-flow adjustments.
- Manual validation target:
  - open vault import / "Add Device"
  - grant camera permission
  - return from Android settings
  - confirm the scanner recognizes granted permission and stops re-requesting access
### Things reviewers should pay attention to
- scripts/fdroid-build.sh : confirm removing the expo-camera stub is acceptable for the F-Droid build strategy.
- src/hooks/useQRScanner.js : verify the Android/F-Droid permission refresh logic is scoped appropriately and does not affect normal store builds.
- Confirm that narrowing F-Droid exclusions does not reintroduce unwanted proprietary dependencies while still allowing camera/ML Kit startup to work.
- Check that the F-Droid metadata commit used for validation points to a commit that actually contains these fixes.
### Screenshots/Recordings
[Screen_recording_20260408_164629.webm](https://github.com/user-attachments/assets/a409d36d-bb70-4994-9b80-4f244f38b910)

### dependencies
- Requires F-Droid metadata to point to a commit that includes this PR.
- Related F-Droid metadata update may be needed in gitlab/fdroiddata/metadata/com.pears.pass.yml after merge.
- If validation is done through a fork first, the metadata commit should be updated again once the fix is merged upstream.