### PR TITLE
App preferences v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6306,7 +6306,7 @@
     "node_modules/@tetherto/pearpass-lib-constants": {
       "name": "pearpass-lib-constants",
       "version": "0.0.11",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-constants.git#e8c17313a77c2ac9f45143b8bc24debe2cfbf209",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-constants.git#6ebdf4122533d0f0043919fda80b1d1936343f3b",
       "license": "Apache-2.0"
     },
     "node_modules/@tetherto/pearpass-lib-data-export": {
@@ -6331,7 +6331,7 @@
     "node_modules/@tetherto/pearpass-lib-ui-kit": {
       "name": "pearpass-lib-ui-react-native-components",
       "version": "0.0.40",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#4cd852b21eec5eafd1628e34b0f7a47b17b549e6",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#283de221802356a826de44a3f615711c21a7fcae",
       "license": "Apache-2.0",
       "dependencies": {
         "react-strict-dom": "^0.0.55"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6331,7 +6331,7 @@
     "node_modules/@tetherto/pearpass-lib-ui-kit": {
       "name": "pearpass-lib-ui-react-native-components",
       "version": "0.0.40",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#283de221802356a826de44a3f615711c21a7fcae",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#f579665c6b8729bfd1ea50504d2812fc5dec452d",
       "license": "Apache-2.0",
       "dependencies": {
         "react-strict-dom": "^0.0.55"

--- a/src/app/App/index.jsx
+++ b/src/app/App/index.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react'
 
+import { rawTokens } from '@tetherto/pearpass-lib-ui-kit'
 import { OtpRefreshProvider } from '@tetherto/pearpass-lib-vault'
+import { View } from 'react-native'
 import Toast from 'react-native-toast-message'
 
 import { Navigation } from '../Navigation'
@@ -43,6 +45,13 @@ export const App = () => {
         config={{
           baseToast: ({ text1, renderLeadingIcon }) => (
             <ToastCard text1={text1} renderLeadingIcon={renderLeadingIcon} />
+          ),
+          alertToast: ({ props }) => (
+            <View
+              style={{ width: '100%', paddingHorizontal: rawTokens.spacing16 }}
+            >
+              {props?.render?.()}
+            </View>
           )
         }}
       />

--- a/src/app/Navigation/index.jsx
+++ b/src/app/Navigation/index.jsx
@@ -29,6 +29,7 @@ import {
 import { RecordDetails } from '../../screens/RecordDetails'
 import { AboutV2 } from '../../screens/Settings/About/AboutV2'
 import { AppearanceV2 } from '../../screens/Settings/Appearance/AppearanceV2'
+import { AppPreferences } from '../../screens/Settings/AppPreferences'
 import { Feedback } from '../../screens/Settings/Feedback'
 import { MasterPassword } from '../../screens/Settings/MasterPassword'
 import { MyDevices } from '../../screens/Settings/MyDevices'
@@ -120,6 +121,7 @@ export const Navigation = ({ initialRouteName }) => (
       name="CreateFolder"
       component={isV2() ? CreateFolderV2 : CreateFolder}
     />
+    <Stack.Screen name="AppPreferences" component={AppPreferences} />
     <Stack.Screen name="MasterPassword" component={MasterPassword} />
     <Stack.Screen name="BlindPeering" component={BlindPeeringSectionV2} />
     <Stack.Screen name="ImportVault" component={ImportVault} />

--- a/src/app/TabNavigator/TabNavigatorV2.tsx
+++ b/src/app/TabNavigator/TabNavigatorV2.tsx
@@ -1,6 +1,9 @@
+import { useCallback } from 'react'
+
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
+import { useLingui } from '@lingui/react/macro'
 import { AUTHENTICATOR_ENABLED } from '@tetherto/pearpass-lib-constants'
-import { useTheme, rawTokens, Text } from '@tetherto/pearpass-lib-ui-kit'
+import { AlertMessage, useTheme, rawTokens, Text } from '@tetherto/pearpass-lib-ui-kit'
 import {
   LockFilled,
   LockOutlined,
@@ -10,14 +13,64 @@ import {
   Settings as SettingsIcon,
   SettingsOutlined,
 } from '@tetherto/pearpass-lib-ui-kit/icons'
-import { StyleSheet, View } from 'react-native'
+import { Pressable, StyleSheet, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import Toast from 'react-native-toast-message'
 
 import { DrawerNavigator } from '../DrawerNavigator'
 import { SettingsNavigator } from '../SettingsNavigator'
 import { Authenticator } from '../../screens/Authenticator'
+import { useVaultSelector } from '../../context/VaultSelectorContext'
 
 const Tab = createBottomTabNavigator()
+
+const VaultTabButton = ({ onPress, onLongPress: _onLongPress, accessibilityState, ...rest }: Record<string, unknown>) => {
+  const { t } = useLingui()
+  const { theme } = useTheme()
+  const insets = useSafeAreaInsets()
+  const { open: openVaultSelector } = useVaultSelector()
+  const isFocused = (accessibilityState as { selected?: boolean })?.selected
+  const toastOffset = 66 + insets.bottom + 8
+
+  const handlePress = useCallback(() => {
+    if (isFocused) {
+      Toast.show({
+        type: 'alertToast',
+        props: {
+          render: () => (
+            <AlertMessage
+              variant="info"
+              size="small"
+              backgroundColor={theme.colors.backgroundSnackbar}
+              color={theme.colors.colorOnPrimary}
+              title=""
+              description={t`Press and hold to open vault manager`}
+            />
+          )
+        },
+        position: 'bottom',
+        bottomOffset: toastOffset
+      })
+      return
+    }
+    (onPress as () => void)?.()
+  }, [isFocused, onPress, t, toastOffset])
+
+  const handleLongPress = useCallback(() => {
+    if (isFocused) {
+      openVaultSelector()
+    }
+  }, [isFocused, openVaultSelector])
+
+  return (
+    <Pressable
+      {...rest}
+      accessibilityState={accessibilityState}
+      onPress={handlePress}
+      onLongPress={handleLongPress}
+    />
+  )
+}
 
 export const TabNavigatorV2 = () => {
   const { theme } = useTheme()
@@ -107,7 +160,11 @@ export const TabNavigatorV2 = () => {
         }
       })}
     >
-      <Tab.Screen name="MainDrawerNavigator" component={DrawerNavigator} />
+      <Tab.Screen
+        name="MainDrawerNavigator"
+        component={DrawerNavigator}
+        options={{ tabBarButton: (props) => <VaultTabButton {...props} /> }}
+      />
 
       {AUTHENTICATOR_ENABLED && (
         <Tab.Screen name="Authenticator" component={Authenticator} />
@@ -123,5 +180,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: rawTokens.spacing2
-  },
+  }
 })
+

--- a/src/app/TabNavigator/TabNavigatorV2.tsx
+++ b/src/app/TabNavigator/TabNavigatorV2.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from 'react'
 
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
+import { createBottomTabNavigator, type BottomTabBarButtonProps } from '@react-navigation/bottom-tabs'
 import { useLingui } from '@lingui/react/macro'
 import { AUTHENTICATOR_ENABLED } from '@tetherto/pearpass-lib-constants'
-import { AlertMessage, useTheme, rawTokens, Text } from '@tetherto/pearpass-lib-ui-kit'
+import { useTheme, rawTokens, Text } from '@tetherto/pearpass-lib-ui-kit'
 import {
   LockFilled,
   LockOutlined,
@@ -13,48 +13,46 @@ import {
   Settings as SettingsIcon,
   SettingsOutlined,
 } from '@tetherto/pearpass-lib-ui-kit/icons'
-import { Pressable, StyleSheet, View } from 'react-native'
+import { type GestureResponderEvent, Pressable, StyleSheet, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import Toast from 'react-native-toast-message'
 
 import { DrawerNavigator } from '../DrawerNavigator'
 import { SettingsNavigator } from '../SettingsNavigator'
 import { Authenticator } from '../../screens/Authenticator'
 import { useVaultSelector } from '../../context/VaultSelectorContext'
+import { showInfoAlertToast } from '../../utils/showInfoAlertToast'
 
 const Tab = createBottomTabNavigator()
 
-const VaultTabButton = ({ onPress, onLongPress: _onLongPress, accessibilityState, ...rest }: Record<string, unknown>) => {
+// Drops onLongPress from props so the spread below doesn't reinstate the
+// Tab Navigator's default long-press handler.
+const VaultTabButton = ({
+  onPress,
+  onLongPress: _onLongPress,
+  accessibilityState,
+  ...rest
+}: BottomTabBarButtonProps) => {
   const { t } = useLingui()
   const { theme } = useTheme()
   const insets = useSafeAreaInsets()
-  const { open: openVaultSelector } = useVaultSelector()
-  const isFocused = (accessibilityState as { selected?: boolean })?.selected
+  const { openVaultSelector } = useVaultSelector()
+  const isFocused = accessibilityState?.selected
   const toastOffset = 66 + insets.bottom + 8
 
-  const handlePress = useCallback(() => {
-    if (isFocused) {
-      Toast.show({
-        type: 'alertToast',
-        props: {
-          render: () => (
-            <AlertMessage
-              variant="info"
-              size="small"
-              backgroundColor={theme.colors.backgroundSnackbar}
-              color={theme.colors.colorOnPrimary}
-              title=""
-              description={t`Press and hold to open vault manager`}
-            />
-          )
-        },
-        position: 'bottom',
-        bottomOffset: toastOffset
-      })
-      return
-    }
-    (onPress as () => void)?.()
-  }, [isFocused, onPress, t, toastOffset])
+  const handlePress = useCallback(
+    (event: GestureResponderEvent) => {
+      if (isFocused) {
+        showInfoAlertToast({
+          theme,
+          description: t`Press and hold to open vault manager`,
+          bottomOffset: toastOffset
+        })
+        return
+      }
+      onPress?.(event)
+    },
+    [isFocused, onPress, t, theme, toastOffset]
+  )
 
   const handleLongPress = useCallback(() => {
     if (isFocused) {
@@ -183,4 +181,3 @@ const styles = StyleSheet.create({
     gap: rawTokens.spacing2
   }
 })
-

--- a/src/constants/secureStorageKeys.js
+++ b/src/constants/secureStorageKeys.js
@@ -7,5 +7,8 @@ export const SECURE_STORAGE_KEYS = {
   BIOMETRICS_ENABLED: 'biometricsEnabled',
   COPY_TO_CLIPBOARD: 'copyToClipboard',
   ACCEPTED_TERMS: 'acceptedTerms',
-  HAPTICS_ENABLED: 'hapticsEnabled'
+  HAPTICS_ENABLED: 'hapticsEnabled',
+  ALLOW_NON_SECURE_WEBSITES: 'allowNonSecureWebsites',
+  CLIPBOARD_CLEAR_TIMEOUT: 'clipboardClearTimeout',
+  PIN_ENABLED: 'pinEnabled'
 }

--- a/src/containers/BottomSheet/OptionsSheet.jsx
+++ b/src/containers/BottomSheet/OptionsSheet.jsx
@@ -1,0 +1,33 @@
+import { NavbarListItem } from '@tetherto/pearpass-lib-ui-kit'
+import { View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+import { SheetHeader } from './SheetHeader'
+
+export const OptionsSheet = ({
+  title,
+  options,
+  selectedValue,
+  onSelect,
+  onClose
+}) => {
+  const { bottom } = useSafeAreaInsets()
+
+  return (
+    <View>
+      <SheetHeader showHandle title={title} onClose={onClose} />
+      <View style={{ paddingBottom: bottom }}>
+        {options.map((option, index) => (
+          <NavbarListItem
+            key={String(option.value)}
+            label={option.label}
+            selected={option.value === selectedValue}
+            platform="mobile"
+            showDivider={index < options.length - 1}
+            onClick={() => onSelect(option.value)}
+          />
+        ))}
+      </View>
+    </View>
+  )
+}

--- a/src/containers/BottomSheet/SheetHeader.jsx
+++ b/src/containers/BottomSheet/SheetHeader.jsx
@@ -9,6 +9,16 @@ import { Close } from '@tetherto/pearpass-lib-ui-kit/icons'
 import { View } from 'react-native'
 
 const styles = {
+  handleArea: {
+    alignItems: 'center',
+    paddingTop: rawTokens.spacing12,
+    paddingBottom: rawTokens.spacing8
+  },
+  handle: {
+    width: 32,
+    height: 4,
+    borderRadius: 10
+  },
   header: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -25,12 +35,22 @@ const styles = {
   }
 }
 
-export const SheetHeader = ({ title, onClose }) => {
+export const SheetHeader = ({ title, onClose, showHandle = false }) => {
   const { t } = useLingui()
   const { theme } = useTheme()
 
   return (
     <>
+      {showHandle && (
+        <View style={styles.handleArea}>
+          <View
+            style={[
+              styles.handle,
+              { backgroundColor: theme.colors.colorBorderSecondary }
+            ]}
+          />
+        </View>
+      )}
       <View style={styles.header}>
         <View style={styles.headerSpacer} />
         <Text variant="bodyEmphasized" style={styles.headerTitle}>

--- a/src/containers/BottomSheetRecordActionsContentV2/index.jsx
+++ b/src/containers/BottomSheetRecordActionsContentV2/index.jsx
@@ -96,8 +96,8 @@ export const BottomSheetRecordActionsContentV2 = ({
         ? [{ icon: CheckBox, label: t`Select Item`, onPress: handleSelectItem }]
         : []),
       ...(UNSUPPORTED
-        ? []
-        : [{ icon: Share, label: t`Share Item`, onPress: () => {} }]),
+        ? [{ icon: Share, label: t`Share Item`, onPress: () => {} }]
+        : []),
       {
         icon: DriveFileMoveOutlined,
         label: t`Move to Another Folder`,

--- a/src/containers/ContentHeader/index.jsx
+++ b/src/containers/ContentHeader/index.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useLingui } from '@lingui/react/macro'
 import { useNavigation } from '@react-navigation/native'
@@ -22,6 +22,7 @@ import Svg, { Defs, LinearGradient, Rect, Stop } from 'react-native-svg'
 
 import { createStyles } from './styles'
 import { useSharedFilter } from '../../context/SharedFilterContext'
+import { useVaultSelector } from '../../context/VaultSelectorContext'
 import { useRecordMenuItems } from '../../hooks/useRecordMenuItems'
 import { BottomSheetCategorySelectorContent } from '../BottomSheetCategorySelectorContent'
 import { BottomSheetFolderSelectorContent } from '../BottomSheetFolderSelectorContent'
@@ -82,7 +83,18 @@ export const ContentHeader = ({
   const { state } = useSharedFilter()
   const styles = createStyles(theme.colors)
   const menuItems = useRecordMenuItems({ exclude: ['password'] })
+  const { isOpen: isVaultSelectorRequested, close: closeVaultSelectorRequest } =
+    useVaultSelector()
   const [isVaultSelectorOpen, setIsVaultSelectorOpen] = useState(false)
+  const prevRequested = useRef(false)
+
+  useEffect(() => {
+    if (isVaultSelectorRequested && !prevRequested.current) {
+      setIsVaultSelectorOpen(true)
+      closeVaultSelectorRequest()
+    }
+    prevRequested.current = isVaultSelectorRequested
+  }, [isVaultSelectorRequested, closeVaultSelectorRequest])
 
   const bgColor = theme.colors.colorSurfacePrimary
   const vaultName = vaultData?.name || t`Personal Vault`

--- a/src/containers/ContentHeader/index.jsx
+++ b/src/containers/ContentHeader/index.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { useLingui } from '@lingui/react/macro'
 import { useNavigation } from '@react-navigation/native'
@@ -22,7 +22,7 @@ import Svg, { Defs, LinearGradient, Rect, Stop } from 'react-native-svg'
 
 import { createStyles } from './styles'
 import { useSharedFilter } from '../../context/SharedFilterContext'
-import { useVaultSelector } from '../../context/VaultSelectorContext'
+import { useRegisterVaultSelectorOpener } from '../../context/VaultSelectorContext'
 import { useRecordMenuItems } from '../../hooks/useRecordMenuItems'
 import { BottomSheetCategorySelectorContent } from '../BottomSheetCategorySelectorContent'
 import { BottomSheetFolderSelectorContent } from '../BottomSheetFolderSelectorContent'
@@ -83,18 +83,10 @@ export const ContentHeader = ({
   const { state } = useSharedFilter()
   const styles = createStyles(theme.colors)
   const menuItems = useRecordMenuItems({ exclude: ['password'] })
-  const { isOpen: isVaultSelectorRequested, close: closeVaultSelectorRequest } =
-    useVaultSelector()
   const [isVaultSelectorOpen, setIsVaultSelectorOpen] = useState(false)
-  const prevRequested = useRef(false)
 
-  useEffect(() => {
-    if (isVaultSelectorRequested && !prevRequested.current) {
-      setIsVaultSelectorOpen(true)
-      closeVaultSelectorRequest()
-    }
-    prevRequested.current = isVaultSelectorRequested
-  }, [isVaultSelectorRequested, closeVaultSelectorRequest])
+  const openVaultSelector = useCallback(() => setIsVaultSelectorOpen(true), [])
+  useRegisterVaultSelectorOpener(openVaultSelector)
 
   const bgColor = theme.colors.colorSurfacePrimary
   const vaultName = vaultData?.name || t`Personal Vault`

--- a/src/containers/ScreenHeader/index.tsx
+++ b/src/containers/ScreenHeader/index.tsx
@@ -56,7 +56,8 @@ const styles = StyleSheet.create({
   headerContent: {
     flexDirection: 'row',
     alignItems: 'center',
-    padding: rawTokens.spacing16,
+    paddingHorizontal: rawTokens.spacing8,
+    paddingVertical: rawTokens.spacing16,
     gap: rawTokens.spacing8,
   },
   leftContainer: {

--- a/src/context/VaultSelectorContext.jsx
+++ b/src/context/VaultSelectorContext.jsx
@@ -1,22 +1,44 @@
-import { createContext, useCallback, useContext, useState } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef
+} from 'react'
 
 const VaultSelectorContext = createContext({
-  isOpen: false,
-  open: () => {},
-  close: () => {}
+  registerOpener: () => () => {},
+  openVaultSelector: () => {}
 })
 
 export const VaultSelectorProvider = ({ children }) => {
-  const [isOpen, setIsOpen] = useState(false)
+  const openerRef = useRef(null)
 
-  const open = useCallback(() => setIsOpen(true), [])
-  const close = useCallback(() => setIsOpen(false), [])
+  const registerOpener = useCallback((fn) => {
+    openerRef.current = fn
+    return () => {
+      if (openerRef.current === fn) {
+        openerRef.current = null
+      }
+    }
+  }, [])
+
+  const openVaultSelector = useCallback(() => {
+    openerRef.current?.()
+  }, [])
 
   return (
-    <VaultSelectorContext.Provider value={{ isOpen, open, close }}>
+    <VaultSelectorContext.Provider
+      value={{ registerOpener, openVaultSelector }}
+    >
       {children}
     </VaultSelectorContext.Provider>
   )
 }
 
 export const useVaultSelector = () => useContext(VaultSelectorContext)
+
+export const useRegisterVaultSelectorOpener = (open) => {
+  const { registerOpener } = useVaultSelector()
+  useEffect(() => registerOpener(open), [registerOpener, open])
+}

--- a/src/context/VaultSelectorContext.jsx
+++ b/src/context/VaultSelectorContext.jsx
@@ -1,0 +1,22 @@
+import { createContext, useCallback, useContext, useState } from 'react'
+
+const VaultSelectorContext = createContext({
+  isOpen: false,
+  open: () => {},
+  close: () => {}
+})
+
+export const VaultSelectorProvider = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = useCallback(() => setIsOpen(true), [])
+  const close = useCallback(() => setIsOpen(false), [])
+
+  return (
+    <VaultSelectorContext.Provider value={{ isOpen, open, close }}>
+      {children}
+    </VaultSelectorContext.Provider>
+  )
+}
+
+export const useVaultSelector = () => useContext(VaultSelectorContext)

--- a/src/hooks/useCopyToClipboard.js
+++ b/src/hooks/useCopyToClipboard.js
@@ -20,6 +20,9 @@ export const useCopyToClipboard = () => {
   const [isCopyToClipboardEnabled, setIsCopyToClipboardEnabled] =
     useState(false)
   const [isCopied, setIsCopied] = useState(false)
+  const [clipboardTimeout, setClipboardTimeout] = useState(
+    CLIPBOARD_CLEAR_TIMEOUT
+  )
   const timeoutRef = useRef(null)
   const clearClipboardTimeoutRef = useRef(null)
   const lastCopiedTextRef = useRef(null)
@@ -27,7 +30,7 @@ export const useCopyToClipboard = () => {
   const { hapticSuccess } = useHapticFeedback()
 
   useEffect(() => {
-    const checkCopyToClipboardOptIn = async () => {
+    const loadSettings = async () => {
       const optIn = await SecureStore.getItemAsync(
         SECURE_STORAGE_KEYS.COPY_TO_CLIPBOARD,
         {
@@ -35,9 +38,18 @@ export const useCopyToClipboard = () => {
         }
       )
       setIsCopyToClipboardEnabled(optIn !== 'false')
+
+      const storedTimeout = await SecureStore.getItemAsync(
+        SECURE_STORAGE_KEYS.CLIPBOARD_CLEAR_TIMEOUT
+      )
+      if (storedTimeout === 'null') {
+        setClipboardTimeout(null)
+      } else if (storedTimeout !== null) {
+        setClipboardTimeout(Number(storedTimeout))
+      }
     }
 
-    checkCopyToClipboardOptIn()
+    loadSettings()
 
     return () => {
       if (timeoutRef.current) {
@@ -78,33 +90,37 @@ export const useCopyToClipboard = () => {
           clearTimeout(globalClearTimer)
         }
 
-        const nativeAvailable = await NativeClipboard.isAvailable()
-
-        if (nativeAvailable) {
-          await NativeClipboard.setStringWithExpiration(
-            text,
-            CLIPBOARD_CLEAR_TIMEOUT / 1000
-          )
-        } else {
+        if (clipboardTimeout === null) {
           await Clipboard.setStringAsync(text)
+        } else {
+          const nativeAvailable = await NativeClipboard.isAvailable()
 
-          const timerId = setTimeout(async () => {
-            try {
-              const currentClipboardText = await Clipboard.getStringAsync()
+          if (nativeAvailable) {
+            await NativeClipboard.setStringWithExpiration(
+              text,
+              clipboardTimeout / 1000
+            )
+          } else {
+            await Clipboard.setStringAsync(text)
 
-              if (
-                currentClipboardText === lastCopiedTextRef.current ||
-                currentClipboardText === globalLastCopiedText
-              ) {
-                await Clipboard.setStringAsync('')
-                lastCopiedTextRef.current = null
-                globalLastCopiedText = null
-              }
-            } catch {}
-          }, CLIPBOARD_CLEAR_TIMEOUT)
+            const timerId = setTimeout(async () => {
+              try {
+                const currentClipboardText = await Clipboard.getStringAsync()
 
-          clearClipboardTimeoutRef.current = timerId
-          globalClearTimer = timerId
+                if (
+                  currentClipboardText === lastCopiedTextRef.current ||
+                  currentClipboardText === globalLastCopiedText
+                ) {
+                  await Clipboard.setStringAsync('')
+                  lastCopiedTextRef.current = null
+                  globalLastCopiedText = null
+                }
+              } catch {}
+            }, clipboardTimeout)
+
+            clearClipboardTimeoutRef.current = timerId
+            globalClearTimer = timerId
+          }
         }
 
         setIsCopied(true)
@@ -128,7 +144,7 @@ export const useCopyToClipboard = () => {
         return false
       }
     },
-    [isCopyToClipboardEnabled, t, hapticSuccess]
+    [isCopyToClipboardEnabled, clipboardTimeout, t, hapticSuccess]
   )
 
   return { copyToClipboard, isCopied, isCopyToClipboardEnabled }

--- a/src/hooks/useCopyToClipboard.js
+++ b/src/hooks/useCopyToClipboard.js
@@ -20,9 +20,6 @@ export const useCopyToClipboard = () => {
   const [isCopyToClipboardEnabled, setIsCopyToClipboardEnabled] =
     useState(false)
   const [isCopied, setIsCopied] = useState(false)
-  const [clipboardTimeout, setClipboardTimeout] = useState(
-    CLIPBOARD_CLEAR_TIMEOUT
-  )
   const timeoutRef = useRef(null)
   const clearClipboardTimeoutRef = useRef(null)
   const lastCopiedTextRef = useRef(null)
@@ -30,7 +27,7 @@ export const useCopyToClipboard = () => {
   const { hapticSuccess } = useHapticFeedback()
 
   useEffect(() => {
-    const loadSettings = async () => {
+    const loadOptIn = async () => {
       const optIn = await SecureStore.getItemAsync(
         SECURE_STORAGE_KEYS.COPY_TO_CLIPBOARD,
         {
@@ -38,18 +35,9 @@ export const useCopyToClipboard = () => {
         }
       )
       setIsCopyToClipboardEnabled(optIn !== 'false')
-
-      const storedTimeout = await SecureStore.getItemAsync(
-        SECURE_STORAGE_KEYS.CLIPBOARD_CLEAR_TIMEOUT
-      )
-      if (storedTimeout === 'null') {
-        setClipboardTimeout(null)
-      } else if (storedTimeout !== null) {
-        setClipboardTimeout(Number(storedTimeout))
-      }
     }
 
-    loadSettings()
+    loadOptIn()
 
     return () => {
       if (timeoutRef.current) {
@@ -89,6 +77,14 @@ export const useCopyToClipboard = () => {
         if (globalClearTimer) {
           clearTimeout(globalClearTimer)
         }
+
+        const storedTimeout = await SecureStore.getItemAsync(
+          SECURE_STORAGE_KEYS.CLIPBOARD_CLEAR_TIMEOUT
+        )
+        let clipboardTimeout = CLIPBOARD_CLEAR_TIMEOUT
+        if (storedTimeout === 'null') clipboardTimeout = null
+        else if (storedTimeout !== null)
+          clipboardTimeout = Number(storedTimeout)
 
         if (clipboardTimeout === null) {
           await Clipboard.setStringAsync(text)
@@ -144,7 +140,7 @@ export const useCopyToClipboard = () => {
         return false
       }
     },
-    [isCopyToClipboardEnabled, clipboardTimeout, t, hapticSuccess]
+    [isCopyToClipboardEnabled, t, hapticSuccess]
   )
 
   return { copyToClipboard, isCopied, isCopyToClipboardEnabled }

--- a/src/hooks/useCopyToClipboard.test.js
+++ b/src/hooks/useCopyToClipboard.test.js
@@ -92,7 +92,9 @@ describe('useCopyToClipboard', () => {
   })
 
   it('should copy text to clipboard when opt-in is enabled', async () => {
-    SecureStore.getItemAsync.mockResolvedValue('true')
+    SecureStore.getItemAsync.mockImplementation((key) =>
+      Promise.resolve(key === 'copyToClipboard' ? 'true' : null)
+    )
 
     const { result } = renderWithI18n()
 
@@ -108,7 +110,9 @@ describe('useCopyToClipboard', () => {
   })
 
   it('should set isCopied back to false after timeout', async () => {
-    SecureStore.getItemAsync.mockResolvedValue('true')
+    SecureStore.getItemAsync.mockImplementation((key) =>
+      Promise.resolve(key === 'copyToClipboard' ? 'true' : null)
+    )
 
     const { result } = renderWithI18n()
 
@@ -127,7 +131,9 @@ describe('useCopyToClipboard', () => {
   })
 
   it('should not copy if text is empty, null or undefined', async () => {
-    SecureStore.getItemAsync.mockResolvedValue('true')
+    SecureStore.getItemAsync.mockImplementation((key) =>
+      Promise.resolve(key === 'copyToClipboard' ? 'true' : null)
+    )
 
     const { result } = renderWithI18n()
     await act(async () => {})
@@ -150,7 +156,9 @@ describe('useCopyToClipboard', () => {
   })
 
   it('should clear previous timeout when copying again', async () => {
-    SecureStore.getItemAsync.mockResolvedValue('true')
+    SecureStore.getItemAsync.mockImplementation((key) =>
+      Promise.resolve(key === 'copyToClipboard' ? 'true' : null)
+    )
 
     const { result } = renderWithI18n()
     await act(async () => {})
@@ -166,7 +174,9 @@ describe('useCopyToClipboard', () => {
   })
 
   it('should return true when copy is successful', async () => {
-    SecureStore.getItemAsync.mockResolvedValue('true')
+    SecureStore.getItemAsync.mockImplementation((key) =>
+      Promise.resolve(key === 'copyToClipboard' ? 'true' : null)
+    )
 
     const { result } = renderWithI18n()
     await act(async () => {})
@@ -180,7 +190,9 @@ describe('useCopyToClipboard', () => {
 
   describe('auto-clear clipboard', () => {
     it('should clear clipboard after 30 seconds if it still contains the same value', async () => {
-      SecureStore.getItemAsync.mockResolvedValue('true')
+      SecureStore.getItemAsync.mockImplementation((key) =>
+        Promise.resolve(key === 'copyToClipboard' ? 'true' : null)
+      )
       Clipboard.getStringAsync.mockResolvedValue('sensitive password')
 
       const { result } = renderWithI18n()
@@ -205,7 +217,9 @@ describe('useCopyToClipboard', () => {
     })
 
     it('should not clear clipboard if value has changed', async () => {
-      SecureStore.getItemAsync.mockResolvedValue('true')
+      SecureStore.getItemAsync.mockImplementation((key) =>
+        Promise.resolve(key === 'copyToClipboard' ? 'true' : null)
+      )
       Clipboard.getStringAsync.mockResolvedValue('different value')
 
       const { result } = renderWithI18n()
@@ -230,7 +244,9 @@ describe('useCopyToClipboard', () => {
     })
 
     it('should cancel previous clear timeout when copying again', async () => {
-      SecureStore.getItemAsync.mockResolvedValue('true')
+      SecureStore.getItemAsync.mockImplementation((key) =>
+        Promise.resolve(key === 'copyToClipboard' ? 'true' : null)
+      )
       Clipboard.getStringAsync.mockResolvedValue('second password')
 
       const { result } = renderWithI18n()
@@ -264,7 +280,9 @@ describe('useCopyToClipboard', () => {
     })
 
     it('should handle errors during clipboard clearing gracefully', async () => {
-      SecureStore.getItemAsync.mockResolvedValue('true')
+      SecureStore.getItemAsync.mockImplementation((key) =>
+        Promise.resolve(key === 'copyToClipboard' ? 'true' : null)
+      )
       Clipboard.getStringAsync.mockRejectedValue(
         new Error('Clipboard access failed')
       )
@@ -285,7 +303,9 @@ describe('useCopyToClipboard', () => {
     })
 
     it('should cancel clipboard clear timer on unmount', async () => {
-      SecureStore.getItemAsync.mockResolvedValue('true')
+      SecureStore.getItemAsync.mockImplementation((key) =>
+        Promise.resolve(key === 'copyToClipboard' ? 'true' : null)
+      )
       Clipboard.getStringAsync.mockResolvedValue('sensitive password')
 
       const { result, unmount } = renderWithI18n()

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -29,6 +29,7 @@ import { HapticsProvider } from './context/HapticsContext'
 import { LoadingProvider } from './context/LoadingContext'
 import { ModalProvider } from './context/ModalContext'
 import { SharedFilterProvider } from './context/SharedFilterContext'
+import { VaultSelectorProvider } from './context/VaultSelectorContext'
 import { messages } from './locales/en/messages'
 import { logger } from './utils/logger'
 import * as SplashScreen from './utils/SplashScreen'
@@ -97,21 +98,23 @@ export const Main = () => {
                 <SafeAreaProvider>
                   <VaultProvider>
                     <SharedFilterProvider>
-                      <NavigationContainer>
-                        <AutoLockProvider>
-                          <AutoLockTouchCapture>
-                            <ModalProvider>
-                              <BottomSheetProvider>
-                                <BottomSheetV2Provider>
-                                  <BottomSheetModalProvider>
-                                    <App />
-                                  </BottomSheetModalProvider>
-                                </BottomSheetV2Provider>
-                              </BottomSheetProvider>
-                            </ModalProvider>
-                          </AutoLockTouchCapture>
-                        </AutoLockProvider>
-                      </NavigationContainer>
+                      <VaultSelectorProvider>
+                        <NavigationContainer>
+                          <AutoLockProvider>
+                            <AutoLockTouchCapture>
+                              <ModalProvider>
+                                <BottomSheetProvider>
+                                  <BottomSheetV2Provider>
+                                    <BottomSheetModalProvider>
+                                      <App />
+                                    </BottomSheetModalProvider>
+                                  </BottomSheetV2Provider>
+                                </BottomSheetProvider>
+                              </ModalProvider>
+                            </AutoLockTouchCapture>
+                          </AutoLockProvider>
+                        </NavigationContainer>
+                      </VaultSelectorProvider>
                     </SharedFilterProvider>
                   </VaultProvider>
                 </SafeAreaProvider>

--- a/src/screens/Settings/AppPreferences/index.jsx
+++ b/src/screens/Settings/AppPreferences/index.jsx
@@ -1,0 +1,580 @@
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
+
+import { useLingui } from '@lingui/react/macro'
+import { useNavigation } from '@react-navigation/native'
+import {
+  AUTO_LOCK_TIMEOUT_OPTIONS,
+  UNSUPPORTED
+} from '@tetherto/pearpass-lib-constants'
+import {
+  Button,
+  ContextMenu,
+  NavbarListItem,
+  PageHeader,
+  Text,
+  ToggleSwitch,
+  rawTokens,
+  useTheme
+} from '@tetherto/pearpass-lib-ui-kit'
+import {
+  Check,
+  ExpandMore,
+  InfoOutlined,
+  Key,
+  MoreVert,
+  TrashOutlined
+} from '@tetherto/pearpass-lib-ui-kit/icons'
+import * as SecureStore from 'expo-secure-store'
+import { AppState, Pressable, StyleSheet, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+import { SECURE_STORAGE_KEYS } from '../../../constants/secureStorageKeys'
+import { SheetHeader } from '../../../containers/BottomSheet/SheetHeader'
+import { Layout } from '../../../containers/Layout'
+import { BackScreenHeader } from '../../../containers/ScreenHeader/BackScreenHeader'
+import { useAutoLockContext } from '../../../context/AutoLockContext'
+import { useBottomSheet } from '../../../context/BottomSheetContext'
+import { useBiometricsAuthentication } from '../../../hooks/useBiometricsAuthentication'
+import { usePasswordChangeReminder } from '../../../hooks/usePasswordChangeReminder'
+import {
+  isAutofillEnabled as checkAutofillEnabled,
+  openAutofillSettings,
+  requestToEnableAutofill
+} from '../../../utils/AutofillModule'
+
+const DEFAULT_CLIPBOARD_TIMEOUT = 60000
+
+export const AppPreferences = () => {
+  const { t } = useLingui()
+  const navigation = useNavigation()
+  const { theme } = useTheme()
+  const { expand, collapse } = useBottomSheet()
+  const { autoLockTimeout, setAutoLockTimeout } = useAutoLockContext()
+  const { isPasswordChangeReminderEnabled } = usePasswordChangeReminder()
+  const { isBiometricsSupported, isBiometricsEnabled, toggleBiometrics } =
+    useBiometricsAuthentication()
+  const { bottom } = useSafeAreaInsets()
+
+  const [isAutofillEnabled, setIsAutofillEnabled] = useState(false)
+  const [clipboardClearTimeout, setClipboardClearTimeout] = useState(
+    DEFAULT_CLIPBOARD_TIMEOUT
+  )
+  const [isNonSecureAllowed, setIsNonSecureAllowed] = useState(false)
+  const [isPinEnabled, setIsPinEnabled] = useState(false)
+  const [isRemindersEnabled, setIsRemindersEnabled] = useState(true)
+  const appStateRef = useRef(AppState.currentState)
+
+  const clipboardTimeoutOptions = useMemo(
+    () => [
+      { label: t`1 Minute`, value: 60000 },
+      { label: t`3 Minutes`, value: 180000 },
+      { label: t`5 Minutes`, value: 300000 },
+      { label: t`10 Minutes`, value: 600000 },
+      { label: t`30 Minutes`, value: 1800000 },
+      { label: t`1 Hour`, value: 3600000 },
+      { label: t`3 Hours`, value: 10800000 },
+      { label: t`Never`, value: null }
+    ],
+    [t]
+  )
+
+  const autoLockOptions = useMemo(
+    () =>
+      Object.values(AUTO_LOCK_TIMEOUT_OPTIONS).map((option) => ({
+        label: t(option.label),
+        value: option.value
+      })),
+    [t]
+  )
+
+  const refreshAutofillStatus = useCallback(async () => {
+    const enabled = await checkAutofillEnabled()
+    setIsAutofillEnabled(enabled)
+  }, [])
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      const [clipTimeout, nonSecure, pin] = await Promise.all([
+        SecureStore.getItemAsync(SECURE_STORAGE_KEYS.CLIPBOARD_CLEAR_TIMEOUT),
+        SecureStore.getItemAsync(SECURE_STORAGE_KEYS.ALLOW_NON_SECURE_WEBSITES),
+        SecureStore.getItemAsync(SECURE_STORAGE_KEYS.PIN_ENABLED)
+      ])
+
+      if (clipTimeout === 'null') {
+        setClipboardClearTimeout(null)
+      } else if (clipTimeout !== null) {
+        setClipboardClearTimeout(Number(clipTimeout))
+      }
+      setIsNonSecureAllowed(nonSecure === 'true')
+      setIsPinEnabled(pin === 'true')
+      setIsRemindersEnabled(isPasswordChangeReminderEnabled)
+    }
+
+    refreshAutofillStatus()
+    loadSettings()
+  }, [isPasswordChangeReminderEnabled, refreshAutofillStatus])
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextAppState) => {
+      if (
+        appStateRef.current.match(/inactive|background/) &&
+        nextAppState === 'active'
+      ) {
+        refreshAutofillStatus()
+      }
+      appStateRef.current = nextAppState
+    })
+
+    return () => subscription.remove()
+  }, [refreshAutofillStatus])
+
+  const handleAutofillToggle = useCallback(async () => {
+    if (isAutofillEnabled) {
+      await openAutofillSettings()
+    } else {
+      await requestToEnableAutofill()
+    }
+  }, [isAutofillEnabled])
+
+  const handleNonSecureToggle = useCallback(async (checked) => {
+    setIsNonSecureAllowed(checked)
+    if (checked) {
+      await SecureStore.setItemAsync(
+        SECURE_STORAGE_KEYS.ALLOW_NON_SECURE_WEBSITES,
+        'true'
+      )
+    } else {
+      await SecureStore.deleteItemAsync(
+        SECURE_STORAGE_KEYS.ALLOW_NON_SECURE_WEBSITES
+      )
+    }
+  }, [])
+
+  const handleRemindersToggle = useCallback(async (checked) => {
+    setIsRemindersEnabled(checked)
+    if (checked) {
+      await SecureStore.deleteItemAsync(
+        SECURE_STORAGE_KEYS.IS_PASSWORD_CHANGE_REMINDER_ENABLED
+      )
+    } else {
+      await SecureStore.setItemAsync(
+        SECURE_STORAGE_KEYS.IS_PASSWORD_CHANGE_REMINDER_ENABLED,
+        'false'
+      )
+    }
+  }, [])
+
+  const handleClipboardTimeoutSelect = useCallback(
+    async (value) => {
+      setClipboardClearTimeout(value)
+      await SecureStore.setItemAsync(
+        SECURE_STORAGE_KEYS.CLIPBOARD_CLEAR_TIMEOUT,
+        value === null ? 'null' : String(value)
+      )
+      collapse()
+    },
+    [collapse]
+  )
+
+  const handleAutoLockSelect = useCallback(
+    (value) => {
+      setAutoLockTimeout(value)
+      collapse()
+    },
+    [setAutoLockTimeout, collapse]
+  )
+
+  const handlePinToggle = useCallback(async () => {
+    const newValue = !isPinEnabled
+    setIsPinEnabled(newValue)
+    if (newValue) {
+      await SecureStore.setItemAsync(SECURE_STORAGE_KEYS.PIN_ENABLED, 'true')
+    } else {
+      await SecureStore.deleteItemAsync(SECURE_STORAGE_KEYS.PIN_ENABLED)
+    }
+  }, [isPinEnabled])
+
+  const handleBiometricsToggle = useCallback(async () => {
+    await toggleBiometrics(!isBiometricsEnabled)
+  }, [isBiometricsEnabled, toggleBiometrics])
+
+  const clipboardTimeoutLabel = useMemo(() => {
+    const option = clipboardTimeoutOptions.find(
+      (opt) => opt.value === clipboardClearTimeout
+    )
+    return option ? option.label : clipboardTimeoutOptions[0].label
+  }, [clipboardClearTimeout, clipboardTimeoutOptions])
+
+  const autoLockLabel = useMemo(() => {
+    const option = autoLockOptions.find((opt) => opt.value === autoLockTimeout)
+    return option ? option.label : ''
+  }, [autoLockTimeout, autoLockOptions])
+
+  const openClipboardPicker = useCallback(() => {
+    expand({
+      children: (
+        <View>
+          <SheetHeader
+            showHandle
+            title={t`Clear Clipboard`}
+            onClose={collapse}
+          />
+          <View style={{ paddingBottom: bottom }}>
+            {clipboardTimeoutOptions.map((option, index) => (
+              <NavbarListItem
+                key={String(option.value)}
+                label={option.label}
+                selected={option.value === clipboardClearTimeout}
+                platform="mobile"
+                showDivider={index < clipboardTimeoutOptions.length - 1}
+                onClick={() => handleClipboardTimeoutSelect(option.value)}
+              />
+            ))}
+          </View>
+        </View>
+      ),
+      snapPoints: ['10%', '60%']
+    })
+  }, [
+    t,
+    collapse,
+    expand,
+    clipboardTimeoutOptions,
+    clipboardClearTimeout,
+    handleClipboardTimeoutSelect
+  ])
+
+  const openAutoLockPicker = useCallback(() => {
+    expand({
+      children: (
+        <View>
+          <SheetHeader showHandle title={t`Auto Lock`} onClose={collapse} />
+          <View style={{ paddingBottom: bottom }}>
+            {autoLockOptions.map((option, index) => (
+              <NavbarListItem
+                key={String(option.value)}
+                label={option.label}
+                selected={option.value === autoLockTimeout}
+                platform="mobile"
+                showDivider={index < autoLockOptions.length - 1}
+                onClick={() => handleAutoLockSelect(option.value)}
+              />
+            ))}
+          </View>
+        </View>
+      ),
+      snapPoints: ['10%', '60%']
+    })
+  }, [
+    t,
+    collapse,
+    expand,
+    autoLockOptions,
+    autoLockTimeout,
+    handleAutoLockSelect
+  ])
+
+  const styles = getStyles(theme)
+
+  return (
+    <Layout
+      scrollable
+      header={
+        <BackScreenHeader
+          title={t`Settings`}
+          onBack={() => navigation.goBack()}
+        />
+      }
+      contentStyle={styles.content}
+    >
+      <PageHeader
+        title={t`App Preferences`}
+        subtitle={t`Control how PearPass works and keep your vault secure.`}
+      />
+
+      {/* Autofill & Browsing */}
+      <View style={styles.section}>
+        <Text variant="caption" color={theme.colors.colorTextSecondary}>
+          {t`Autofill & Browsing`}
+        </Text>
+        <View style={styles.card}>
+          <View style={styles.cardRow}>
+            <ToggleSwitch
+              checked={isAutofillEnabled}
+              onChange={handleAutofillToggle}
+              label={t`Autofill`}
+              description={t`Automatically fill usernames, passwords, and codes when you sign in`}
+            />
+          </View>
+          <View style={styles.cardRow}>
+            <View style={styles.dropdownColumn}>
+              <View style={styles.rowTextContent}>
+                <Text variant="labelEmphasized">{t`Clear Clipboard`}</Text>
+                <Text variant="caption" color={theme.colors.colorTextSecondary}>
+                  {t`Automatically remove copied credentials from your clipboard after a set time`}
+                </Text>
+              </View>
+              <Pressable
+                style={styles.dropdownFull}
+                onPress={openClipboardPicker}
+              >
+                <Text variant="labelEmphasized">{clipboardTimeoutLabel}</Text>
+                <ExpandMore
+                  width={14}
+                  height={14}
+                  color={theme.colors.colorTextPrimary}
+                />
+              </Pressable>
+            </View>
+          </View>
+          <View style={styles.cardRowLast}>
+            <ToggleSwitch
+              checked={isNonSecureAllowed}
+              onChange={handleNonSecureToggle}
+              label={t`Allow non-secure websites`}
+              description={t`Allow autofill and access on HTTP websites. When disabled, only secure HTTPS sites are supported`}
+            />
+          </View>
+        </View>
+      </View>
+
+      {/* Unlock Method */}
+      <View style={styles.section}>
+        <View style={styles.sectionLabelRow}>
+          <Text variant="caption" color={theme.colors.colorTextSecondary}>
+            {t`Unlock Method`}
+          </Text>
+          <InfoOutlined
+            width={14}
+            height={14}
+            color={theme.colors.colorTextSecondary}
+          />
+        </View>
+        <View style={styles.card}>
+          <View style={styles.cardRow}>
+            <View style={styles.checkboxRowInner}>
+              <View
+                style={[
+                  styles.checkbox,
+                  styles.checkboxChecked,
+                  styles.checkboxDisabled
+                ]}
+              >
+                <Check
+                  width={12}
+                  height={12}
+                  color={theme.colors.colorSurfacePrimary}
+                />
+              </View>
+              <View style={styles.rowTextContent}>
+                <Text variant="labelEmphasized">{t`Master Password`}</Text>
+                <Text variant="caption" color={theme.colors.colorTextSecondary}>
+                  {t`Use your master password to unlock PearPass and decrypt your vault`}
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          {UNSUPPORTED && (
+            <View style={styles.cardRow}>
+              <View style={styles.checkboxRowInner}>
+                <Pressable
+                  style={[
+                    styles.checkbox,
+                    isPinEnabled && styles.checkboxChecked
+                  ]}
+                  onPress={handlePinToggle}
+                >
+                  {isPinEnabled && (
+                    <Check
+                      width={12}
+                      height={12}
+                      color={theme.colors.colorSurfacePrimary}
+                    />
+                  )}
+                </Pressable>
+                <View style={styles.rowTextContent}>
+                  <Text variant="labelEmphasized">{t`Pin Code`}</Text>
+                  <Text
+                    variant="caption"
+                    color={theme.colors.colorTextSecondary}
+                  >
+                    {t`Use a short PIN to quickly unlock PearPass on this device`}
+                  </Text>
+                </View>
+                {isPinEnabled && (
+                  <ContextMenu
+                    trigger={
+                      <Button
+                        variant="tertiary"
+                        size="small"
+                        iconBefore={
+                          <MoreVert color={theme.colors.colorTextPrimary} />
+                        }
+                      />
+                    }
+                  >
+                    <View style={{ paddingBottom: bottom }}>
+                      <NavbarListItem
+                        platform="mobile"
+                        icon={<Key color={theme.colors.colorTextPrimary} />}
+                        label={t`Change PIN Code`}
+                        showDivider
+                      />
+                      <NavbarListItem
+                        platform="mobile"
+                        variant="destructive"
+                        icon={
+                          <TrashOutlined
+                            color={theme.colors.colorSurfaceDestructiveElevated}
+                          />
+                        }
+                        label={t`Delete PIN Code`}
+                      />
+                    </View>
+                  </ContextMenu>
+                )}
+              </View>
+            </View>
+          )}
+
+          <View style={styles.cardRowLast}>
+            <View style={styles.checkboxRowInner}>
+              <Pressable
+                style={[
+                  styles.checkbox,
+                  isBiometricsEnabled && styles.checkboxChecked
+                ]}
+                onPress={handleBiometricsToggle}
+                disabled={!isBiometricsSupported}
+              >
+                {isBiometricsEnabled && (
+                  <Check
+                    width={12}
+                    height={12}
+                    color={theme.colors.colorSurfacePrimary}
+                  />
+                )}
+              </Pressable>
+              <View style={styles.rowTextContent}>
+                <Text variant="labelEmphasized">{t`Biometrics`}</Text>
+                <Text variant="caption" color={theme.colors.colorTextSecondary}>
+                  {t`Use your device's built-in authentications (Face ID, fingerprint, or system PIN)`}
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+
+      {/* Security Awareness */}
+      <View style={styles.section}>
+        <Text variant="caption" color={theme.colors.colorTextSecondary}>
+          {t`Security Awareness`}
+        </Text>
+        <View style={styles.card}>
+          <View style={styles.cardRow}>
+            <View style={styles.dropdownColumn}>
+              <View style={styles.rowTextContent}>
+                <Text variant="labelEmphasized">{t`Auto Lock`}</Text>
+                <Text variant="caption" color={theme.colors.colorTextSecondary}>
+                  {t`Automatically lock the app after selected period of inactivity`}
+                </Text>
+              </View>
+              <Pressable
+                style={styles.dropdownFull}
+                onPress={openAutoLockPicker}
+              >
+                <Text variant="labelEmphasized">{autoLockLabel}</Text>
+                <ExpandMore
+                  width={14}
+                  height={14}
+                  color={theme.colors.colorTextPrimary}
+                />
+              </Pressable>
+            </View>
+          </View>
+          <View style={styles.cardRowLast}>
+            <ToggleSwitch
+              checked={isRemindersEnabled}
+              onChange={handleRemindersToggle}
+              label={t`Reminders`}
+              description={t`Get alerts when it's time to update your passwords`}
+            />
+          </View>
+        </View>
+      </View>
+    </Layout>
+  )
+}
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    content: {
+      gap: rawTokens.spacing20,
+      flexGrow: 1,
+      paddingBottom: rawTokens.spacing40
+    },
+    section: {
+      gap: rawTokens.spacing12
+    },
+    sectionLabelRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: rawTokens.spacing4
+    },
+    card: {
+      borderWidth: 1,
+      borderColor: theme.colors.colorBorderPrimary,
+      borderRadius: rawTokens.radius8,
+      overflow: 'hidden'
+    },
+    cardRow: {
+      paddingHorizontal: rawTokens.spacing12,
+      paddingVertical: rawTokens.spacing16,
+      borderBottomWidth: 1,
+      borderBottomColor: theme.colors.colorBorderPrimary
+    },
+    cardRowLast: {
+      paddingHorizontal: rawTokens.spacing12,
+      paddingVertical: rawTokens.spacing16
+    },
+    dropdownColumn: {
+      gap: rawTokens.spacing12
+    },
+    rowTextContent: {
+      flex: 1,
+      gap: rawTokens.spacing4
+    },
+    dropdownFull: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: rawTokens.spacing12,
+      paddingVertical: rawTokens.spacing12,
+      borderWidth: 1,
+      borderColor: theme.colors.colorBorderPrimary,
+      borderRadius: rawTokens.radius8
+    },
+    checkboxRowInner: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: rawTokens.spacing12
+    },
+    checkbox: {
+      width: 16,
+      height: 16,
+      borderRadius: 4,
+      borderWidth: 1,
+      borderColor: theme.colors.colorBorderSecondary,
+      alignItems: 'center',
+      justifyContent: 'center'
+    },
+    checkboxChecked: {
+      backgroundColor: theme.colors.colorPrimary,
+      borderColor: theme.colors.colorPrimary
+    },
+    checkboxDisabled: {
+      opacity: 0.25
+    }
+  })

--- a/src/screens/Settings/AppPreferences/index.jsx
+++ b/src/screens/Settings/AppPreferences/index.jsx
@@ -4,10 +4,10 @@ import { useLingui } from '@lingui/react/macro'
 import { useNavigation } from '@react-navigation/native'
 import {
   AUTO_LOCK_TIMEOUT_OPTIONS,
+  CLIPBOARD_CLEAR_TIMEOUT,
   UNSUPPORTED
 } from '@tetherto/pearpass-lib-constants'
 import {
-  AlertMessage,
   Button,
   Checkbox,
   ContextMenu,
@@ -28,11 +28,9 @@ import {
 import * as SecureStore from 'expo-secure-store'
 import { AppState, Platform, Pressable, StyleSheet, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import Toast from 'react-native-toast-message'
 
 import { SECURE_STORAGE_KEYS } from '../../../constants/secureStorageKeys'
-import { TOAST_CONFIG } from '../../../constants/toast'
-import { SheetHeader } from '../../../containers/BottomSheet/SheetHeader'
+import { OptionsSheet } from '../../../containers/BottomSheet/OptionsSheet'
 import { Layout } from '../../../containers/Layout'
 import { BackScreenHeader } from '../../../containers/ScreenHeader/BackScreenHeader'
 import { useAutoLockContext } from '../../../context/AutoLockContext'
@@ -44,8 +42,10 @@ import {
   openAutofillSettings,
   requestToEnableAutofill
 } from '../../../utils/AutofillModule'
+import { storeOptionalFlag } from '../../../utils/secureStoreFlag'
+import { showInfoAlertToast } from '../../../utils/showInfoAlertToast'
 
-const DEFAULT_CLIPBOARD_TIMEOUT = 60000
+const SHEET_SNAP_POINTS = ['10%', '60%']
 
 export const AppPreferences = () => {
   const { t } = useLingui()
@@ -60,7 +60,7 @@ export const AppPreferences = () => {
 
   const [isAutofillEnabled, setIsAutofillEnabled] = useState(false)
   const [clipboardClearTimeout, setClipboardClearTimeout] = useState(
-    DEFAULT_CLIPBOARD_TIMEOUT
+    CLIPBOARD_CLEAR_TIMEOUT
   )
   const [isNonSecureAllowed, setIsNonSecureAllowed] = useState(false)
   const [isPinEnabled, setIsPinEnabled] = useState(false)
@@ -69,6 +69,7 @@ export const AppPreferences = () => {
 
   const clipboardTimeoutOptions = useMemo(
     () => [
+      { label: t`30 Seconds`, value: 30000 },
       { label: t`1 Minute`, value: 60000 },
       { label: t`3 Minutes`, value: 180000 },
       { label: t`5 Minutes`, value: 300000 },
@@ -141,60 +142,38 @@ export const AppPreferences = () => {
       Platform.OS === 'ios' &&
       Number(String(Platform.Version).split('.')[0]) >= 18
 
-    if (isIOS18OrNewer) {
-      const enabled = await requestToEnableAutofill()
-      if (!enabled) {
-        Toast.show({
-          type: 'alertToast',
-          props: {
-            render: () => (
-              <AlertMessage
-                variant="info"
-                size="small"
-                backgroundColor={theme.colors.backgroundSnackbar}
-                color={theme.colors.colorOnPrimary}
-                title=""
-                description={t`Autofill couldn't be enabled`}
-                actionText={t`Open Settings`}
-                onAction={() => openAutofillSettings()}
-              />
-            )
-          },
-          position: 'bottom',
-          bottomOffset: TOAST_CONFIG.BOTTOM_OFFSET
-        })
-      }
-    } else {
+    if (!isIOS18OrNewer) {
       await openAutofillSettings()
+      return
     }
-  }, [isAutofillEnabled])
+
+    const enabled = await requestToEnableAutofill()
+    if (!enabled) {
+      showInfoAlertToast({
+        theme,
+        description: t`Autofill couldn't be enabled`,
+        actionText: t`Open Settings`,
+        onAction: () => openAutofillSettings()
+      })
+    }
+  }, [isAutofillEnabled, t, theme])
 
   const handleNonSecureToggle = useCallback(async (checked) => {
     setIsNonSecureAllowed(checked)
-    if (checked) {
-      await SecureStore.setItemAsync(
-        SECURE_STORAGE_KEYS.ALLOW_NON_SECURE_WEBSITES,
-        'true'
-      )
-    } else {
-      await SecureStore.deleteItemAsync(
-        SECURE_STORAGE_KEYS.ALLOW_NON_SECURE_WEBSITES
-      )
-    }
+    await storeOptionalFlag(
+      SECURE_STORAGE_KEYS.ALLOW_NON_SECURE_WEBSITES,
+      checked,
+      false
+    )
   }, [])
 
   const handleRemindersToggle = useCallback(async (checked) => {
     setIsRemindersEnabled(checked)
-    if (checked) {
-      await SecureStore.deleteItemAsync(
-        SECURE_STORAGE_KEYS.IS_PASSWORD_CHANGE_REMINDER_ENABLED
-      )
-    } else {
-      await SecureStore.setItemAsync(
-        SECURE_STORAGE_KEYS.IS_PASSWORD_CHANGE_REMINDER_ENABLED,
-        'false'
-      )
-    }
+    await storeOptionalFlag(
+      SECURE_STORAGE_KEYS.IS_PASSWORD_CHANGE_REMINDER_ENABLED,
+      checked,
+      true
+    )
   }, [])
 
   const handleClipboardTimeoutSelect = useCallback(
@@ -220,11 +199,7 @@ export const AppPreferences = () => {
   const handlePinToggle = useCallback(async () => {
     const newValue = !isPinEnabled
     setIsPinEnabled(newValue)
-    if (newValue) {
-      await SecureStore.setItemAsync(SECURE_STORAGE_KEYS.PIN_ENABLED, 'true')
-    } else {
-      await SecureStore.deleteItemAsync(SECURE_STORAGE_KEYS.PIN_ENABLED)
-    }
+    await storeOptionalFlag(SECURE_STORAGE_KEYS.PIN_ENABLED, newValue, false)
   }, [isPinEnabled])
 
   const handleBiometricsToggle = useCallback(async () => {
@@ -235,7 +210,7 @@ export const AppPreferences = () => {
     const option = clipboardTimeoutOptions.find(
       (opt) => opt.value === clipboardClearTimeout
     )
-    return option ? option.label : clipboardTimeoutOptions[0].label
+    return option ? option.label : ''
   }, [clipboardClearTimeout, clipboardTimeoutOptions])
 
   const autoLockLabel = useMemo(() => {
@@ -246,27 +221,15 @@ export const AppPreferences = () => {
   const openClipboardPicker = useCallback(() => {
     expand({
       children: (
-        <View>
-          <SheetHeader
-            showHandle
-            title={t`Clear Clipboard`}
-            onClose={collapse}
-          />
-          <View style={{ paddingBottom: bottom }}>
-            {clipboardTimeoutOptions.map((option, index) => (
-              <NavbarListItem
-                key={String(option.value)}
-                label={option.label}
-                selected={option.value === clipboardClearTimeout}
-                platform="mobile"
-                showDivider={index < clipboardTimeoutOptions.length - 1}
-                onClick={() => handleClipboardTimeoutSelect(option.value)}
-              />
-            ))}
-          </View>
-        </View>
+        <OptionsSheet
+          title={t`Clear Clipboard`}
+          options={clipboardTimeoutOptions}
+          selectedValue={clipboardClearTimeout}
+          onSelect={handleClipboardTimeoutSelect}
+          onClose={collapse}
+        />
       ),
-      snapPoints: ['10%', '60%']
+      snapPoints: SHEET_SNAP_POINTS
     })
   }, [
     t,
@@ -280,23 +243,15 @@ export const AppPreferences = () => {
   const openAutoLockPicker = useCallback(() => {
     expand({
       children: (
-        <View>
-          <SheetHeader showHandle title={t`Auto Lock`} onClose={collapse} />
-          <View style={{ paddingBottom: bottom }}>
-            {autoLockOptions.map((option, index) => (
-              <NavbarListItem
-                key={String(option.value)}
-                label={option.label}
-                selected={option.value === autoLockTimeout}
-                platform="mobile"
-                showDivider={index < autoLockOptions.length - 1}
-                onClick={() => handleAutoLockSelect(option.value)}
-              />
-            ))}
-          </View>
-        </View>
+        <OptionsSheet
+          title={t`Auto Lock`}
+          options={autoLockOptions}
+          selectedValue={autoLockTimeout}
+          onSelect={handleAutoLockSelect}
+          onClose={collapse}
+        />
       ),
-      snapPoints: ['10%', '60%']
+      snapPoints: SHEET_SNAP_POINTS
     })
   }, [
     t,
@@ -308,6 +263,9 @@ export const AppPreferences = () => {
   ])
 
   const styles = getStyles(theme)
+
+  const cardRowStyle = (isLast) =>
+    isLast ? styles.cardRow : [styles.cardRow, styles.cardRowDivider]
 
   return (
     <Layout
@@ -331,7 +289,7 @@ export const AppPreferences = () => {
           {t`Autofill & Browsing`}
         </Text>
         <View style={styles.card}>
-          <View style={styles.cardRow}>
+          <View style={cardRowStyle(false)}>
             <ToggleSwitch
               checked={isAutofillEnabled}
               onChange={handleAutofillToggle}
@@ -339,7 +297,7 @@ export const AppPreferences = () => {
               description={t`Automatically fill usernames, passwords, and codes when you sign in`}
             />
           </View>
-          <View style={UNSUPPORTED ? styles.cardRow : styles.cardRowLast}>
+          <View style={cardRowStyle(!UNSUPPORTED)}>
             <View style={styles.dropdownColumn}>
               <View style={styles.rowTextContent}>
                 <Text variant="labelEmphasized">{t`Clear Clipboard`}</Text>
@@ -361,7 +319,7 @@ export const AppPreferences = () => {
             </View>
           </View>
           {UNSUPPORTED && (
-            <View style={styles.cardRowLast}>
+            <View style={cardRowStyle(true)}>
               <ToggleSwitch
                 checked={isNonSecureAllowed}
                 onChange={handleNonSecureToggle}
@@ -386,7 +344,7 @@ export const AppPreferences = () => {
           />
         </View>
         <View style={styles.card}>
-          <View style={styles.cardRow}>
+          <View style={cardRowStyle(false)}>
             <Checkbox
               checked
               disabled
@@ -396,7 +354,7 @@ export const AppPreferences = () => {
           </View>
 
           {UNSUPPORTED && (
-            <View style={styles.cardRow}>
+            <View style={cardRowStyle(false)}>
               <View style={styles.checkboxRowInner}>
                 <Checkbox
                   checked={isPinEnabled}
@@ -440,7 +398,7 @@ export const AppPreferences = () => {
             </View>
           )}
 
-          <View style={styles.cardRowLast}>
+          <View style={cardRowStyle(true)}>
             <Checkbox
               checked={isBiometricsEnabled}
               onChange={handleBiometricsToggle}
@@ -458,7 +416,7 @@ export const AppPreferences = () => {
           {t`Security Awareness`}
         </Text>
         <View style={styles.card}>
-          <View style={styles.cardRow}>
+          <View style={cardRowStyle(false)}>
             <View style={styles.dropdownColumn}>
               <View style={styles.rowTextContent}>
                 <Text variant="labelEmphasized">{t`Auto Lock`}</Text>
@@ -479,7 +437,7 @@ export const AppPreferences = () => {
               </Pressable>
             </View>
           </View>
-          <View style={styles.cardRowLast}>
+          <View style={cardRowStyle(true)}>
             <ToggleSwitch
               checked={isRemindersEnabled}
               onChange={handleRemindersToggle}
@@ -516,13 +474,11 @@ const getStyles = (theme) =>
     },
     cardRow: {
       paddingHorizontal: rawTokens.spacing12,
-      paddingVertical: rawTokens.spacing16,
+      paddingVertical: rawTokens.spacing16
+    },
+    cardRowDivider: {
       borderBottomWidth: 1,
       borderBottomColor: theme.colors.colorBorderPrimary
-    },
-    cardRowLast: {
-      paddingHorizontal: rawTokens.spacing12,
-      paddingVertical: rawTokens.spacing16
     },
     dropdownColumn: {
       gap: rawTokens.spacing12

--- a/src/screens/Settings/AppPreferences/index.jsx
+++ b/src/screens/Settings/AppPreferences/index.jsx
@@ -7,7 +7,9 @@ import {
   UNSUPPORTED
 } from '@tetherto/pearpass-lib-constants'
 import {
+  AlertMessage,
   Button,
+  Checkbox,
   ContextMenu,
   NavbarListItem,
   PageHeader,
@@ -17,7 +19,6 @@ import {
   useTheme
 } from '@tetherto/pearpass-lib-ui-kit'
 import {
-  Check,
   ExpandMore,
   InfoOutlined,
   Key,
@@ -25,10 +26,12 @@ import {
   TrashOutlined
 } from '@tetherto/pearpass-lib-ui-kit/icons'
 import * as SecureStore from 'expo-secure-store'
-import { AppState, Pressable, StyleSheet, View } from 'react-native'
+import { AppState, Platform, Pressable, StyleSheet, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import Toast from 'react-native-toast-message'
 
 import { SECURE_STORAGE_KEYS } from '../../../constants/secureStorageKeys'
+import { TOAST_CONFIG } from '../../../constants/toast'
 import { SheetHeader } from '../../../containers/BottomSheet/SheetHeader'
 import { Layout } from '../../../containers/Layout'
 import { BackScreenHeader } from '../../../containers/ScreenHeader/BackScreenHeader'
@@ -131,8 +134,38 @@ export const AppPreferences = () => {
   const handleAutofillToggle = useCallback(async () => {
     if (isAutofillEnabled) {
       await openAutofillSettings()
+      return
+    }
+
+    const isIOS18OrNewer =
+      Platform.OS === 'ios' &&
+      Number(String(Platform.Version).split('.')[0]) >= 18
+
+    if (isIOS18OrNewer) {
+      const enabled = await requestToEnableAutofill()
+      if (!enabled) {
+        Toast.show({
+          type: 'alertToast',
+          props: {
+            render: () => (
+              <AlertMessage
+                variant="info"
+                size="small"
+                backgroundColor={theme.colors.backgroundSnackbar}
+                color={theme.colors.colorOnPrimary}
+                title=""
+                description={t`Autofill couldn't be enabled`}
+                actionText={t`Open Settings`}
+                onAction={() => openAutofillSettings()}
+              />
+            )
+          },
+          position: 'bottom',
+          bottomOffset: TOAST_CONFIG.BOTTOM_OFFSET
+        })
+      }
     } else {
-      await requestToEnableAutofill()
+      await openAutofillSettings()
     }
   }, [isAutofillEnabled])
 
@@ -354,56 +387,23 @@ export const AppPreferences = () => {
         </View>
         <View style={styles.card}>
           <View style={styles.cardRow}>
-            <View style={styles.checkboxRowInner}>
-              <View
-                style={[
-                  styles.checkbox,
-                  styles.checkboxChecked,
-                  styles.checkboxDisabled
-                ]}
-              >
-                <Check
-                  width={12}
-                  height={12}
-                  color={theme.colors.colorSurfacePrimary}
-                />
-              </View>
-              <View style={styles.rowTextContent}>
-                <Text variant="labelEmphasized">{t`Master Password`}</Text>
-                <Text variant="caption" color={theme.colors.colorTextSecondary}>
-                  {t`Use your master password to unlock PearPass and decrypt your vault`}
-                </Text>
-              </View>
-            </View>
+            <Checkbox
+              checked
+              disabled
+              label={t`Master Password`}
+              description={t`Use your master password to unlock PearPass and decrypt your vault`}
+            />
           </View>
 
           {UNSUPPORTED && (
             <View style={styles.cardRow}>
               <View style={styles.checkboxRowInner}>
-                <Pressable
-                  style={[
-                    styles.checkbox,
-                    isPinEnabled && styles.checkboxChecked
-                  ]}
-                  onPress={handlePinToggle}
-                >
-                  {isPinEnabled && (
-                    <Check
-                      width={12}
-                      height={12}
-                      color={theme.colors.colorSurfacePrimary}
-                    />
-                  )}
-                </Pressable>
-                <View style={styles.rowTextContent}>
-                  <Text variant="labelEmphasized">{t`Pin Code`}</Text>
-                  <Text
-                    variant="caption"
-                    color={theme.colors.colorTextSecondary}
-                  >
-                    {t`Use a short PIN to quickly unlock PearPass on this device`}
-                  </Text>
-                </View>
+                <Checkbox
+                  checked={isPinEnabled}
+                  onChange={handlePinToggle}
+                  label={t`Pin Code`}
+                  description={t`Use a short PIN to quickly unlock PearPass on this device`}
+                />
                 {isPinEnabled && (
                   <ContextMenu
                     trigger={
@@ -441,30 +441,13 @@ export const AppPreferences = () => {
           )}
 
           <View style={styles.cardRowLast}>
-            <View style={styles.checkboxRowInner}>
-              <Pressable
-                style={[
-                  styles.checkbox,
-                  isBiometricsEnabled && styles.checkboxChecked
-                ]}
-                onPress={handleBiometricsToggle}
-                disabled={!isBiometricsSupported}
-              >
-                {isBiometricsEnabled && (
-                  <Check
-                    width={12}
-                    height={12}
-                    color={theme.colors.colorSurfacePrimary}
-                  />
-                )}
-              </Pressable>
-              <View style={styles.rowTextContent}>
-                <Text variant="labelEmphasized">{t`Biometrics`}</Text>
-                <Text variant="caption" color={theme.colors.colorTextSecondary}>
-                  {t`Use your device's built-in authentications (Face ID, fingerprint, or system PIN)`}
-                </Text>
-              </View>
-            </View>
+            <Checkbox
+              checked={isBiometricsEnabled}
+              onChange={handleBiometricsToggle}
+              disabled={!isBiometricsSupported}
+              label={t`Biometrics`}
+              description={t`Use your device's built-in authentications (Face ID, fingerprint, or system PIN)`}
+            />
           </View>
         </View>
       </View>
@@ -562,21 +545,5 @@ const getStyles = (theme) =>
       flexDirection: 'row',
       alignItems: 'center',
       gap: rawTokens.spacing12
-    },
-    checkbox: {
-      width: 16,
-      height: 16,
-      borderRadius: 4,
-      borderWidth: 1,
-      borderColor: theme.colors.colorBorderSecondary,
-      alignItems: 'center',
-      justifyContent: 'center'
-    },
-    checkboxChecked: {
-      backgroundColor: theme.colors.colorPrimary,
-      borderColor: theme.colors.colorPrimary
-    },
-    checkboxDisabled: {
-      opacity: 0.25
     }
   })

--- a/src/screens/Settings/AppPreferences/index.jsx
+++ b/src/screens/Settings/AppPreferences/index.jsx
@@ -306,7 +306,7 @@ export const AppPreferences = () => {
               description={t`Automatically fill usernames, passwords, and codes when you sign in`}
             />
           </View>
-          <View style={styles.cardRow}>
+          <View style={UNSUPPORTED ? styles.cardRow : styles.cardRowLast}>
             <View style={styles.dropdownColumn}>
               <View style={styles.rowTextContent}>
                 <Text variant="labelEmphasized">{t`Clear Clipboard`}</Text>
@@ -327,14 +327,16 @@ export const AppPreferences = () => {
               </Pressable>
             </View>
           </View>
-          <View style={styles.cardRowLast}>
-            <ToggleSwitch
-              checked={isNonSecureAllowed}
-              onChange={handleNonSecureToggle}
-              label={t`Allow non-secure websites`}
-              description={t`Allow autofill and access on HTTP websites. When disabled, only secure HTTPS sites are supported`}
-            />
-          </View>
+          {UNSUPPORTED && (
+            <View style={styles.cardRowLast}>
+              <ToggleSwitch
+                checked={isNonSecureAllowed}
+                onChange={handleNonSecureToggle}
+                label={t`Allow non-secure websites`}
+                description={t`Allow autofill and access on HTTP websites. When disabled, only secure HTTPS sites are supported`}
+              />
+            </View>
+          )}
         </View>
       </View>
 

--- a/src/screens/Settings/SettingsV2.jsx
+++ b/src/screens/Settings/SettingsV2.jsx
@@ -51,7 +51,7 @@ export const SettingsV2 = () => {
           {
             key: 'app-preferences',
             label: t`App Preferences`,
-            screen: 'Security',
+            screen: 'AppPreferences',
             icon: SettingsApplicationsFilled
           },
           {

--- a/src/screens/Settings/SettingsV2.jsx
+++ b/src/screens/Settings/SettingsV2.jsx
@@ -242,19 +242,21 @@ export const SettingsV2 = () => {
                           }
                         ]}
                       />
-                      <NavbarListItem
-                        label={item.label}
-                        variant="secondary"
-                        size="big"
-                        icon={
-                          <ItemIcon color={theme.colors.colorTextSecondary} />
-                        }
-                        onClick={
-                          item.screen
-                            ? () => navigation.navigate(item.screen)
-                            : undefined
-                        }
-                      />
+                      <View style={styles.itemWrapper}>
+                        <NavbarListItem
+                          label={item.label}
+                          variant="secondary"
+                          size="big"
+                          icon={
+                            <ItemIcon color={theme.colors.colorTextSecondary} />
+                          }
+                          onClick={
+                            item.screen
+                              ? () => navigation.navigate(item.screen)
+                              : undefined
+                          }
+                        />
+                      </View>
                     </View>
                   )
                 })}
@@ -313,6 +315,10 @@ const styles = StyleSheet.create({
     borderLeftWidth: 1,
     borderBottomWidth: 1,
     borderBottomLeftRadius: rawTokens.spacing8
+  },
+  itemWrapper: {
+    borderRadius: rawTokens.radius8,
+    overflow: 'hidden'
   },
   emptyState: {
     paddingHorizontal: rawTokens.spacing16,

--- a/src/utils/secureStoreFlag.js
+++ b/src/utils/secureStoreFlag.js
@@ -1,0 +1,9 @@
+import * as SecureStore from 'expo-secure-store'
+
+export const storeOptionalFlag = async (key, value, defaultValue) => {
+  if (value === defaultValue) {
+    await SecureStore.deleteItemAsync(key)
+  } else {
+    await SecureStore.setItemAsync(key, String(value))
+  }
+}

--- a/src/utils/showInfoAlertToast.jsx
+++ b/src/utils/showInfoAlertToast.jsx
@@ -1,0 +1,41 @@
+import { AlertMessage } from '@tetherto/pearpass-lib-ui-kit'
+import Toast from 'react-native-toast-message'
+
+import { TOAST_CONFIG } from '../constants/toast'
+
+/**
+ * @param {{
+ *   theme: { colors: { backgroundSnackbar: string, colorOnPrimary: string } },
+ *   description: string,
+ *   actionText?: string,
+ *   onAction?: () => void,
+ *   bottomOffset?: number
+ * }} options
+ */
+export const showInfoAlertToast = ({
+  theme,
+  description,
+  actionText,
+  onAction,
+  bottomOffset = TOAST_CONFIG.BOTTOM_OFFSET
+}) => {
+  Toast.show({
+    type: 'alertToast',
+    props: {
+      render: () => (
+        <AlertMessage
+          variant="info"
+          size="small"
+          backgroundColor={theme.colors.backgroundSnackbar}
+          color={theme.colors.colorOnPrimary}
+          title=""
+          description={description}
+          actionText={actionText}
+          onAction={onAction}
+        />
+      )
+    },
+    position: 'bottom',
+    bottomOffset
+  })
+}


### PR DESCRIPTION
### Changes

- Add App Preferences v2 screen (replaces Security settings)
  - Autofill toggle (reads OS state, opens system settings)
  - Clear Clipboard time picker (configurable timeout)
  - Allow non-secure websites toggle (behind UNSUPPORTED flag)
  - Unlock Method section: Master Password (always on), Pin Code (behind UNSUPPORTED flag), Biometrics
  - Auto Lock time picker
  - Reminders toggle
- Add `showHandle` prop to `SheetHeader` for bottom sheet drag handles
- Make clipboard clear timeout configurable in `useCopyToClipboard`
- Add rounded corners to settings menu item press highlight
- Fix `ScreenHeader` padding (horizontal 8, vertical 16)
- Add vault tab interactions:
  - Press when on vault screen → info toast ("Press and hold to open vault manager")
  - Long press when on vault screen → opens vault selector
- Add `alertToast` type to toast config for rendering custom components
- Add `VaultSelectorContext` for tab-to-content communication
- Add `backgroundColor` and `color` props to `AlertMessage` (ui-kit)
- Add `info` variant to `AlertMessage` (ui-kit)

### Screenshots/Recordings

- V2 design on iOS 26.2 iPhone 16e simulator

https://github.com/user-attachments/assets/2d6b977b-06f7-448a-b8e0-8ece8d53988b


Note: native autofill enable popup doesn't work consecutively right away, so added a fallback toast.

- V1 design smoke test

https://github.com/user-attachments/assets/e6410b9b-4e82-4fc0-b9d9-36d5d574ecc0




### Dependencies

- https://github.com/tetherto/pearpass-lib-ui-react-native-components/pull/75
- https://github.com/tetherto/pearpass-lib-constants/pull/31