### PR TITLE
fix: adding testIDs to the mobile password

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21792,12 +21792,6 @@
       "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==",
       "license": "MIT"
     },
-    "node_modules/string-hash-64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
-      "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==",
-      "license": "MIT"
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",

--- a/src/screens/Settings/MasterPassword/PasswordStrengthIndicator.jsx
+++ b/src/screens/Settings/MasterPassword/PasswordStrengthIndicator.jsx
@@ -1,0 +1,89 @@
+import { rawTokens, useTheme } from '@tetherto/pearpass-lib-ui-kit'
+import {
+  DoneAll,
+  GppMaybe,
+  VerifiedUser
+} from '@tetherto/pearpass-lib-ui-kit/icons'
+import { StyleSheet, Text, View } from 'react-native'
+
+const variantIconMap = {
+  vulnerable: GppMaybe,
+  decent: GppMaybe,
+  strong: VerifiedUser,
+  match: DoneAll
+}
+
+const variantLabelMap = {
+  vulnerable: 'Vulnerable',
+  decent: 'Decent',
+  strong: 'Strong',
+  match: 'Match'
+}
+
+const getVariantColor = (variant, colors) => {
+  switch (variant) {
+    case 'vulnerable':
+      return colors.colorSurfaceDestructiveElevated
+    case 'decent':
+      return colors.colorSurfaceWarning
+    case 'strong':
+    case 'match':
+      return colors.colorPrimary
+    default:
+      return undefined
+  }
+}
+
+export const PasswordStrengthIndicator = ({ variant, fieldKey }) => {
+  const { theme } = useTheme()
+
+  if (!variant) {
+    return null
+  }
+
+  const Icon = variantIconMap[variant]
+  const color = getVariantColor(variant, theme.colors)
+  const label = variantLabelMap[variant]
+  const baseTestID = `${fieldKey}_${variant}_indicator`
+
+  return (
+    <>
+      <View style={styles.container} testID={baseTestID}>
+        <View style={styles.iconContainer} testID={`${baseTestID}_icon`}>
+          <Icon width={12} height={12} color={color} />
+        </View>
+        <Text style={[styles.label, { color }]}>{label}</Text>
+      </View>
+      <View
+        style={[
+          styles.divider,
+          { backgroundColor: theme.colors.colorBorderSecondary }
+        ]}
+      />
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: rawTokens.spacing4
+  },
+  iconContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: rawTokens.spacing12,
+    height: rawTokens.spacing12,
+    flexShrink: 0
+  },
+  label: {
+    fontSize: 12,
+    lineHeight: rawTokens.spacing16
+  },
+  divider: {
+    width: 1,
+    height: rawTokens.spacing12,
+    marginHorizontal: rawTokens.spacing8
+  }
+})

--- a/src/screens/Settings/MasterPassword/index.jsx
+++ b/src/screens/Settings/MasterPassword/index.jsx
@@ -11,7 +11,6 @@ import {
   PasswordField,
   rawTokens
 } from '@tetherto/pearpass-lib-ui-kit'
-import { ReportProblem } from '@tetherto/pearpass-lib-ui-kit/icons'
 import { useUserData } from '@tetherto/pearpass-lib-vault'
 import {
   clearBuffer,
@@ -26,6 +25,7 @@ import Toast from 'react-native-toast-message'
 import { Layout } from 'src/containers/Layout'
 import { BackScreenHeader } from 'src/containers/ScreenHeader/BackScreenHeader'
 
+import { PasswordStrengthIndicator } from './PasswordStrengthIndicator'
 import { logger } from '../../../utils/logger'
 
 const STRENGTH_TO_INDICATOR = {
@@ -169,7 +169,12 @@ export const MasterPassword = () => {
           onChangeText={currentPasswordField.onChange}
           variant={currentPasswordField.error ? 'error' : 'default'}
           errorMessage={currentPasswordField.error}
-          passwordIndicator={getPasswordStrength(currentPasswordField.value)}
+          rightSlot={
+            <PasswordStrengthIndicator
+              variant={getPasswordStrength(currentPasswordField.value)}
+              fieldKey="current_password"
+            />
+          }
         />
 
         <PasswordField
@@ -179,7 +184,12 @@ export const MasterPassword = () => {
           onChangeText={newPasswordField.onChange}
           variant={newPasswordField.error ? 'error' : 'default'}
           errorMessage={newPasswordField.error}
-          passwordIndicator={getPasswordStrength(newPasswordField.value)}
+          rightSlot={
+            <PasswordStrengthIndicator
+              variant={getPasswordStrength(newPasswordField.value)}
+              fieldKey="new_password"
+            />
+          }
         />
 
         <PasswordField
@@ -189,17 +199,21 @@ export const MasterPassword = () => {
           onChangeText={repeatPasswordField.onChange}
           variant={repeatPasswordField.error ? 'error' : 'default'}
           errorMessage={repeatPasswordField.error}
-          passwordIndicator={getRepeatIndicator(
-            newPasswordField.value,
-            repeatPasswordField.value
-          )}
+          rightSlot={
+            <PasswordStrengthIndicator
+              variant={getRepeatIndicator(
+                newPasswordField.value,
+                repeatPasswordField.value
+              )}
+              fieldKey="repeat_password"
+            />
+          }
         />
 
         <AlertMessage
           variant="warning"
           size="small"
           description={t`Don't forget your Master password. It's the only way to access your vault. We can't help recover it. Back it up securely.`}
-          icon={<ReportProblem />}
         />
       </View>
     </Layout>


### PR DESCRIPTION
Added testIDs to Master Password strength indicators:

- New `PasswordStrengthIndicator` component with testIDs on chip + icon:
  `{current|new|repeat}_password_{vulnerable|decent|strong|match}_indicator[_icon]`
- Wired into the three `PasswordField` rightSlots on Settings/MasterPassword.
- Removed invalid `icon` prop on `AlertMessage` (rejected by react-strict-dom;
  variant already drives icon).
  

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214186398130135