### PR TITLE
[v2] the "current vault" experience

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ export default {
   preset: 'react-native',
   transform: { '^.+\\.[jt]sx?$': 'babel-jest' },
   moduleNameMapper: {
+    '^src/(.*)$': '<rootDir>/src/$1',
     '^@tetherto/pearpass-lib-ui-theme-provider/native$':
       '<rootDir>/node_modules/@tetherto/pearpass-lib-ui-theme-provider/native/index.js',
     '^@tetherto/pearpass-lib-ui-theme-provider$':

--- a/src/containers/BottomSheetVaultSelectorContent/index.jsx
+++ b/src/containers/BottomSheetVaultSelectorContent/index.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 
+import { useBottomSheetModal } from '@gorhom/bottom-sheet'
 import { useLingui } from '@lingui/react/macro'
 import {
   Button,
@@ -7,8 +8,14 @@ import {
   useBottomSheetClose,
   useTheme
 } from '@tetherto/pearpass-lib-ui-kit'
-import { Add, LockFilled, MoreVert } from '@tetherto/pearpass-lib-ui-kit/icons'
+import {
+  Add,
+  LockFilled,
+  MoreVert,
+  PersonAdd
+} from '@tetherto/pearpass-lib-ui-kit/icons'
 import { useVault, useVaults } from '@tetherto/pearpass-lib-vault'
+import { View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { VAULT_ACTION } from 'src/constants/vaultActions'
 
@@ -32,7 +39,7 @@ export const BottomSheetVaultSelectorContent = ({
   const collapse = useBottomSheetClose()
   const { bottom } = useSafeAreaInsets()
   const { openModal, closeModal } = useModal()
-
+  const { dismiss } = useBottomSheetModal()
   const [menuVault, setMenuVault] = useState(null)
 
   const { data: vaultsData } = useVaults()
@@ -56,6 +63,13 @@ export const BottomSheetVaultSelectorContent = ({
         action={action}
       />
     )
+  }
+
+  const onNavigateToShareVault = (vault) => {
+    onNavigate?.('ShareVault', {
+      vaultId: vault.id,
+      vaultName: vault.name
+    })
   }
 
   const buildVaultActions = (vault) => ({
@@ -82,16 +96,10 @@ export const BottomSheetVaultSelectorContent = ({
       })
     },
     onMembers: () => {
-      onNavigate?.('ShareVault', {
-        vaultId: vault.id,
-        vaultName: vault.name
-      })
+      onNavigateToShareVault(vault)
     },
     onShare: () => {
-      onNavigate?.('ShareVault', {
-        vaultId: vault.id,
-        vaultName: vault.name
-      })
+      onNavigateToShareVault(vault)
     },
     onDelete: () => {
       onNavigate?.('VaultDeleteScreen', {
@@ -114,6 +122,11 @@ export const BottomSheetVaultSelectorContent = ({
     )
   }
 
+  const closeAndRun = (action) => {
+    dismiss()
+    action?.()
+  }
+
   return (
     <Layout
       mode="sheet"
@@ -134,18 +147,30 @@ export const BottomSheetVaultSelectorContent = ({
             style={styles.listItem}
             rightElement={
               isSelected ? (
-                <Button
-                  variant="tertiary"
-                  size="small"
-                  iconBefore={
-                    <MoreVert color={theme.colors.colorTextPrimary} />
-                  }
-                  aria-label={t`Vault actions`}
-                  onClick={() => setMenuVault(vault)}
-                />
+                <View style={styles.rowActions}>
+                  <Button
+                    variant="tertiary"
+                    size="small"
+                    iconBefore={
+                      <PersonAdd color={theme.colors.colorTextPrimary} />
+                    }
+                    onClick={() =>
+                      closeAndRun(() => onNavigateToShareVault(vault))
+                    }
+                  />
+                  <Button
+                    variant="tertiary"
+                    size="small"
+                    iconBefore={
+                      <MoreVert color={theme.colors.colorTextPrimary} />
+                    }
+                    aria-label={t`Vault actions`}
+                    onClick={() => setMenuVault(vault)}
+                  />
+                </View>
               ) : undefined
             }
-            onClick={() => switchVault(vault)}
+            onClick={isSelected ? undefined : () => switchVault(vault)}
           />
         )
       })}

--- a/src/containers/BottomSheetVaultSelectorContent/index.jsx
+++ b/src/containers/BottomSheetVaultSelectorContent/index.jsx
@@ -13,14 +13,13 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { VAULT_ACTION } from 'src/constants/vaultActions'
 
 import { createStyles } from './styles'
-import { useGlobalLoading } from '../../context/LoadingContext'
 import { useModal } from '../../context/ModalContext'
+import { useVaultSwitch } from '../../hooks/useVaultSwitch'
 import { isModifyVaultModalV2Enabled } from '../../utils/modifyVaultModalV2Flag'
 import { SheetHeader } from '../BottomSheet/SheetHeader'
 import { BottomSheetVaultAction } from '../BottomSheetVaultAction'
 import { Layout } from '../Layout'
 import { ModifyVaultModalContentV2 } from '../Modal/ModifyVaultModalContentV2'
-import { VaultPasswordFormModalContent } from '../Modal/VaultPasswordFormModalContent'
 
 export const BottomSheetVaultSelectorContent = ({
   onCreateVault,
@@ -34,57 +33,20 @@ export const BottomSheetVaultSelectorContent = ({
   const { bottom } = useSafeAreaInsets()
   const { openModal, closeModal } = useModal()
 
-  const [isLoading, setIsLoading] = useState(false)
   const [menuVault, setMenuVault] = useState(null)
-  useGlobalLoading({ isLoading })
 
   const { data: vaultsData } = useVaults()
-  const {
-    data: activeVault,
-    isVaultProtected,
-    refetch: refetchVault
-  } = useVault()
+  const { data: activeVault } = useVault()
 
   const closeSelector = () => {
     onRequestClose?.()
     collapse()
   }
 
-  const handleVaultPress = async (vault) => {
-    if (vault.id === activeVault?.id) {
-      closeSelector()
-      return
-    }
-
-    setIsLoading(true)
-    try {
-      const isProtected = await isVaultProtected(vault.id)
-
-      if (isProtected) {
-        setIsLoading(false)
-        openModal(
-          <VaultPasswordFormModalContent
-            vault={vault}
-            onSubmit={async (password) => {
-              setIsLoading(true)
-              try {
-                await refetchVault(vault.id, { password })
-                closeModal()
-                closeSelector()
-              } finally {
-                setIsLoading(false)
-              }
-            }}
-          />
-        )
-      } else {
-        await refetchVault(vault.id)
-        closeSelector()
-      }
-    } finally {
-      setIsLoading(false)
-    }
-  }
+  const { switchVault } = useVaultSwitch({
+    openModal,
+    closeModal
+  })
 
   const openModifyVaultModal = (vault, action) => {
     openModal(
@@ -159,27 +121,34 @@ export const BottomSheetVaultSelectorContent = ({
       contentStyle={{ padding: 0, paddingBottom: bottom }}
       header={<SheetHeader title={t`Vaults`} onClose={closeSelector} />}
     >
-      {vaultsData?.map((vault) => (
-        <ListItem
-          key={vault.id}
-          icon={<LockFilled color={theme.colors.colorTextPrimary} />}
-          title={vault.name}
-          selected={vault.id === activeVault?.id}
-          showDivider
-          iconSize={16}
-          style={styles.listItem}
-          rightElement={
-            <Button
-              variant="tertiary"
-              size="small"
-              iconBefore={<MoreVert color={theme.colors.colorTextPrimary} />}
-              aria-label={t`Vault actions`}
-              onClick={() => setMenuVault(vault)}
-            />
-          }
-          onClick={() => handleVaultPress(vault)}
-        />
-      ))}
+      {vaultsData?.map((vault) => {
+        const isSelected = vault.id === activeVault?.id
+        return (
+          <ListItem
+            key={vault.id}
+            icon={<LockFilled color={theme.colors.colorTextPrimary} />}
+            title={vault.name}
+            selected={isSelected}
+            showDivider
+            iconSize={16}
+            style={styles.listItem}
+            rightElement={
+              isSelected ? (
+                <Button
+                  variant="tertiary"
+                  size="small"
+                  iconBefore={
+                    <MoreVert color={theme.colors.colorTextPrimary} />
+                  }
+                  aria-label={t`Vault actions`}
+                  onClick={() => setMenuVault(vault)}
+                />
+              ) : undefined
+            }
+            onClick={() => switchVault(vault)}
+          />
+        )
+      })}
 
       <ListItem
         icon={<Add color={theme.colors.colorTextPrimary} />}

--- a/src/containers/BottomSheetVaultSelectorContent/index.test.jsx
+++ b/src/containers/BottomSheetVaultSelectorContent/index.test.jsx
@@ -19,6 +19,13 @@ const mockOnCreateVault = jest.fn()
 const mockOnNavigate = jest.fn()
 const mockIsModifyVaultModalV2Enabled = jest.fn(() => false)
 
+jest.mock('@gorhom/bottom-sheet', () => ({
+  useBottomSheetModal: () => ({
+    dismiss: jest.fn(),
+    dismissAll: jest.fn()
+  })
+}))
+
 jest.mock('../../hooks/useVaultSwitch', () => ({
   useVaultSwitch: () => ({ switchVault: mockSwitchVault })
 }))
@@ -44,7 +51,8 @@ jest.mock('@tetherto/pearpass-lib-ui-kit/icons', () => {
   return {
     Add: () => <RN.View testID="icon-add" />,
     LockFilled: () => <RN.View testID="icon-lock" />,
-    MoreVert: () => <RN.View testID="icon-more" />
+    MoreVert: () => <RN.View testID="icon-more" />,
+    PersonAdd: () => <RN.View testID="icon-person-add" />
   }
 })
 
@@ -74,6 +82,9 @@ jest.mock('@tetherto/pearpass-lib-ui-kit', () => {
         <RN.Text testID={`selected-flag-${String(title)}`}>
           {String(!!selected)}
         </RN.Text>
+        <RN.Text testID={`list-item-row-onpress-${String(title)}`}>
+          {onClick ? 'wired' : 'omitted'}
+        </RN.Text>
         <RN.TouchableOpacity
           testID={`list-item-press-${String(title)}`}
           onPress={onClick}
@@ -82,6 +93,7 @@ jest.mock('@tetherto/pearpass-lib-ui-kit', () => {
       </RN.View>
     ),
     rawTokens: {
+      spacing4: 4,
       spacing16: 16
     },
     useBottomSheetClose: () => mockCollapse,
@@ -192,15 +204,25 @@ describe('BottomSheetVaultSelectorContent', () => {
     )
   })
 
-  it('calls switchVault when a vault row is pressed', () => {
+  it('omits row onClick for the active vault only; other vault row switches and calls switchVault', () => {
     const { getByTestId } = renderSheet()
 
-    fireEvent.press(getByTestId('list-item-press-Other Vault'))
+    expect(
+      getByTestId('list-item-row-onpress-Active Vault').props.children
+    ).toBe('omitted')
+    expect(
+      getByTestId('list-item-row-onpress-Other Vault').props.children
+    ).toBe('wired')
 
+    fireEvent.press(getByTestId('list-item-press-Active Vault'))
+    expect(mockSwitchVault).not.toHaveBeenCalled()
+
+    fireEvent.press(getByTestId('list-item-press-Other Vault'))
+    expect(mockSwitchVault).toHaveBeenCalledTimes(1)
     expect(mockSwitchVault).toHaveBeenCalledWith(vaults[1])
   })
 
-  it('shows overflow actions for the active vault and opens the actions panel', () => {
+  it('opens BottomSheetVaultAction when overflow is pressed on the active vault', () => {
     const { getByTestId, queryByTestId } = renderSheet()
 
     expect(getByTestId('vault-overflow-btn')).toBeTruthy()
@@ -213,7 +235,7 @@ describe('BottomSheetVaultSelectorContent', () => {
     )
   })
 
-  it('returns from actions panel to the vault list when back is pressed', () => {
+  it('returns from vault actions to the list when back is pressed', () => {
     const { getByTestId, queryByTestId } = renderSheet()
 
     fireEvent.press(getByTestId('vault-overflow-btn'))
@@ -225,7 +247,7 @@ describe('BottomSheetVaultSelectorContent', () => {
     expect(getByTestId('sheet-header-title')).toBeTruthy()
   })
 
-  it('closes via actions panel onClose using collapse and onRequestClose', () => {
+  it('closes via vault actions onClose using collapse and onRequestClose', () => {
     const { getByTestId } = renderSheet()
 
     fireEvent.press(getByTestId('vault-overflow-btn'))

--- a/src/containers/BottomSheetVaultSelectorContent/index.test.jsx
+++ b/src/containers/BottomSheetVaultSelectorContent/index.test.jsx
@@ -1,0 +1,293 @@
+import { i18n } from '@lingui/core'
+import { I18nProvider } from '@lingui/react'
+import { fireEvent, render } from '@testing-library/react-native'
+
+import { BottomSheetVaultSelectorContent } from './index'
+import messages from '../../locales/en/messages'
+
+i18n.load('en', messages)
+i18n.activate('en')
+
+const mockSwitchVault = jest.fn()
+const mockUseVaults = jest.fn()
+const mockUseVault = jest.fn()
+const mockCollapse = jest.fn()
+const mockOpenModal = jest.fn()
+const mockCloseModal = jest.fn()
+const mockOnRequestClose = jest.fn()
+const mockOnCreateVault = jest.fn()
+const mockOnNavigate = jest.fn()
+const mockIsModifyVaultModalV2Enabled = jest.fn(() => false)
+
+jest.mock('../../hooks/useVaultSwitch', () => ({
+  useVaultSwitch: () => ({ switchVault: mockSwitchVault })
+}))
+
+jest.mock('@tetherto/pearpass-lib-vault', () => ({
+  useVaults: () => mockUseVaults(),
+  useVault: () => mockUseVault()
+}))
+
+jest.mock('../../context/ModalContext', () => ({
+  useModal: () => ({
+    openModal: mockOpenModal,
+    closeModal: mockCloseModal
+  })
+}))
+
+jest.mock('../../utils/modifyVaultModalV2Flag', () => ({
+  isModifyVaultModalV2Enabled: () => mockIsModifyVaultModalV2Enabled()
+}))
+
+jest.mock('@tetherto/pearpass-lib-ui-kit/icons', () => {
+  const RN = require('react-native')
+  return {
+    Add: () => <RN.View testID="icon-add" />,
+    LockFilled: () => <RN.View testID="icon-lock" />,
+    MoreVert: () => <RN.View testID="icon-more" />
+  }
+})
+
+jest.mock('@tetherto/pearpass-lib-ui-kit', () => {
+  const RN = require('react-native')
+  return {
+    Button: ({ onClick, children, 'aria-label': ariaLabel }) => (
+      <RN.TouchableOpacity
+        testID={ariaLabel ? 'vault-overflow-btn' : 'generic-kit-button'}
+        onPress={onClick}
+      >
+        <RN.Text>{children}</RN.Text>
+      </RN.TouchableOpacity>
+    ),
+    ListItem: ({
+      title,
+      onClick,
+      selected,
+      rightElement,
+      icon: _icon,
+      style: _style,
+      showDivider: _showDivider,
+      iconSize: _iconSize
+    }) => (
+      <RN.View testID={`list-item-${String(title)}`}>
+        <RN.Text>{title}</RN.Text>
+        <RN.Text testID={`selected-flag-${String(title)}`}>
+          {String(!!selected)}
+        </RN.Text>
+        <RN.TouchableOpacity
+          testID={`list-item-press-${String(title)}`}
+          onPress={onClick}
+        />
+        {rightElement}
+      </RN.View>
+    ),
+    rawTokens: {
+      spacing16: 16
+    },
+    useBottomSheetClose: () => mockCollapse,
+    useTheme: () => ({
+      theme: {
+        colors: {
+          colorTextPrimary: '#111111'
+        }
+      }
+    })
+  }
+})
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ bottom: 16 })
+}))
+
+jest.mock('../BottomSheet/SheetHeader', () => {
+  const RN = require('react-native')
+  return {
+    SheetHeader: ({ title, onClose }) => (
+      <RN.View testID="sheet-header">
+        <RN.Text testID="sheet-header-title">{title}</RN.Text>
+        <RN.TouchableOpacity testID="sheet-header-close" onPress={onClose} />
+      </RN.View>
+    )
+  }
+})
+
+jest.mock('../Layout', () => {
+  const RN = require('react-native')
+  return {
+    Layout: ({ header, children }) => (
+      <RN.View testID="sheet-layout">
+        {header}
+        {children}
+      </RN.View>
+    )
+  }
+})
+
+jest.mock('../BottomSheetVaultAction', () => {
+  const RN = require('react-native')
+  return {
+    BottomSheetVaultAction: ({
+      vaultName,
+      onBack,
+      onClose,
+      onRename,
+      onPassword
+    }) => (
+      <RN.View testID="vault-actions-panel">
+        <RN.Text testID="vault-actions-name">{vaultName}</RN.Text>
+        <RN.TouchableOpacity testID="vault-actions-back" onPress={onBack} />
+        <RN.TouchableOpacity testID="vault-actions-close" onPress={onClose} />
+        <RN.TouchableOpacity testID="vault-action-rename" onPress={onRename} />
+        <RN.TouchableOpacity
+          testID="vault-action-password"
+          onPress={onPassword}
+        />
+      </RN.View>
+    )
+  }
+})
+
+jest.mock('../Modal/ModifyVaultModalContentV2', () => ({
+  ModifyVaultModalContentV2: () => null
+}))
+
+const vaults = [
+  { id: 'v-active', name: 'Active Vault' },
+  { id: 'v-other', name: 'Other Vault' }
+]
+
+const renderSheet = (props = {}) =>
+  render(
+    <I18nProvider i18n={i18n}>
+      <BottomSheetVaultSelectorContent
+        onRequestClose={mockOnRequestClose}
+        onCreateVault={mockOnCreateVault}
+        onNavigate={mockOnNavigate}
+        {...props}
+      />
+    </I18nProvider>
+  )
+
+describe('BottomSheetVaultSelectorContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsModifyVaultModalV2Enabled.mockReturnValue(false)
+    mockUseVaults.mockReturnValue({
+      data: vaults
+    })
+    mockUseVault.mockReturnValue({
+      data: vaults[0]
+    })
+  })
+
+  it('renders header title and vault rows with selection flag', () => {
+    const { getByTestId } = renderSheet()
+
+    expect(getByTestId('sheet-header-title').props.children).toBe('Vaults')
+    expect(getByTestId('selected-flag-Active Vault').props.children).toBe(
+      'true'
+    )
+    expect(getByTestId('selected-flag-Other Vault').props.children).toBe(
+      'false'
+    )
+  })
+
+  it('calls switchVault when a vault row is pressed', () => {
+    const { getByTestId } = renderSheet()
+
+    fireEvent.press(getByTestId('list-item-press-Other Vault'))
+
+    expect(mockSwitchVault).toHaveBeenCalledWith(vaults[1])
+  })
+
+  it('shows overflow actions for the active vault and opens the actions panel', () => {
+    const { getByTestId, queryByTestId } = renderSheet()
+
+    expect(getByTestId('vault-overflow-btn')).toBeTruthy()
+
+    fireEvent.press(getByTestId('vault-overflow-btn'))
+
+    expect(queryByTestId('vault-actions-panel')).toBeTruthy()
+    expect(getByTestId('vault-actions-name').props.children).toBe(
+      'Active Vault'
+    )
+  })
+
+  it('returns from actions panel to the vault list when back is pressed', () => {
+    const { getByTestId, queryByTestId } = renderSheet()
+
+    fireEvent.press(getByTestId('vault-overflow-btn'))
+    expect(queryByTestId('vault-actions-panel')).toBeTruthy()
+
+    fireEvent.press(getByTestId('vault-actions-back'))
+
+    expect(queryByTestId('vault-actions-panel')).toBeNull()
+    expect(getByTestId('sheet-header-title')).toBeTruthy()
+  })
+
+  it('closes via actions panel onClose using collapse and onRequestClose', () => {
+    const { getByTestId } = renderSheet()
+
+    fireEvent.press(getByTestId('vault-overflow-btn'))
+    fireEvent.press(getByTestId('vault-actions-close'))
+
+    expect(mockOnRequestClose).toHaveBeenCalled()
+    expect(mockCollapse).toHaveBeenCalled()
+  })
+
+  it('closes from header close using collapse and onRequestClose', () => {
+    const { getByTestId } = renderSheet()
+
+    fireEvent.press(getByTestId('sheet-header-close'))
+
+    expect(mockOnRequestClose).toHaveBeenCalled()
+    expect(mockCollapse).toHaveBeenCalled()
+  })
+
+  it('closes sheet and calls onCreateVault when Create New Vault is pressed', () => {
+    const { getByTestId } = renderSheet()
+
+    fireEvent.press(getByTestId('list-item-press-Create New Vault'))
+
+    expect(mockOnRequestClose).toHaveBeenCalled()
+    expect(mockCollapse).toHaveBeenCalled()
+    expect(mockOnCreateVault).toHaveBeenCalled()
+  })
+
+  it('calls onNavigate for rename when modify vault v2 is disabled', () => {
+    mockIsModifyVaultModalV2Enabled.mockReturnValue(false)
+    const { getByTestId } = renderSheet()
+
+    fireEvent.press(getByTestId('vault-overflow-btn'))
+    fireEvent.press(getByTestId('vault-action-rename'))
+
+    expect(mockOnNavigate).toHaveBeenCalledWith('VaultRenameScreen', {
+      vaultId: 'v-active',
+      vaultName: 'Active Vault'
+    })
+  })
+
+  it('opens modal for rename when modify vault v2 is enabled', () => {
+    mockIsModifyVaultModalV2Enabled.mockReturnValue(true)
+    const { getByTestId } = renderSheet()
+
+    fireEvent.press(getByTestId('vault-overflow-btn'))
+    fireEvent.press(getByTestId('vault-action-rename'))
+
+    expect(mockOpenModal).toHaveBeenCalled()
+    expect(mockOnNavigate).not.toHaveBeenCalled()
+  })
+
+  it('calls onNavigate for password when modify vault v2 is disabled', () => {
+    mockIsModifyVaultModalV2Enabled.mockReturnValue(false)
+    const { getByTestId } = renderSheet()
+
+    fireEvent.press(getByTestId('vault-overflow-btn'))
+    fireEvent.press(getByTestId('vault-action-password'))
+
+    expect(mockOnNavigate).toHaveBeenCalledWith('VaultPasswordScreen', {
+      vaultId: 'v-active',
+      vaultName: 'Active Vault'
+    })
+  })
+})

--- a/src/containers/BottomSheetVaultSelectorContent/styles.js
+++ b/src/containers/BottomSheetVaultSelectorContent/styles.js
@@ -4,5 +4,10 @@ export const createStyles = () => ({
   listItem: {
     paddingBlock: rawTokens.spacing16,
     paddingInline: rawTokens.spacing16
+  },
+  rowActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: rawTokens.spacing4
   }
 })

--- a/src/hooks/useVaultSwitch.js
+++ b/src/hooks/useVaultSwitch.js
@@ -1,0 +1,84 @@
+import { useCallback, useState } from 'react'
+
+import { useVault } from '@tetherto/pearpass-lib-vault'
+
+import { VaultPasswordFormModalContent } from '../containers/Modal/VaultPasswordFormModalContent'
+import { useGlobalLoading } from '../context/LoadingContext'
+import { useModal } from '../context/ModalContext'
+
+/**
+ * @param {{
+ *   onSameVault?: () => void;
+ *   onSwitchComplete?: () => void;
+ *   openModal?: (node: React.ReactNode) => void;
+ *   closeModal?: () => void;
+ * }} [options]
+ */
+export const useVaultSwitch = ({
+  onSameVault,
+  onSwitchComplete,
+  openModal: openModalOption,
+  closeModal: closeModalOption
+} = {}) => {
+  const [isLoading, setIsLoading] = useState(false)
+  useGlobalLoading({ isLoading })
+
+  const { openModal: openModalFromContext, closeModal: closeModalFromContext } =
+    useModal()
+  const openModal = openModalOption ?? openModalFromContext
+  const closeModal = closeModalOption ?? closeModalFromContext
+  const {
+    data: activeVault,
+    isVaultProtected,
+    refetch: refetchVault
+  } = useVault()
+
+  const switchVault = useCallback(
+    async (vault) => {
+      if (vault.id === activeVault?.id) {
+        onSameVault?.()
+        return
+      }
+
+      setIsLoading(true)
+      try {
+        const isProtected = await isVaultProtected(vault.id)
+
+        if (isProtected) {
+          setIsLoading(false)
+          openModal(
+            <VaultPasswordFormModalContent
+              vault={vault}
+              onSubmit={async (password) => {
+                setIsLoading(true)
+                try {
+                  await refetchVault(vault.id, { password })
+                  closeModal()
+                  onSwitchComplete?.()
+                } finally {
+                  setIsLoading(false)
+                }
+              }}
+            />
+          )
+        } else {
+          await refetchVault(vault.id)
+          onSwitchComplete?.()
+        }
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [
+      activeVault?.id,
+      closeModal,
+      isVaultProtected,
+      onSameVault,
+      onSwitchComplete,
+      openModal,
+      refetchVault
+    ]
+  )
+
+  return { switchVault }
+}

--- a/src/hooks/useVaultSwitch.test.js
+++ b/src/hooks/useVaultSwitch.test.js
@@ -159,12 +159,45 @@ describe('useVaultSwitch', () => {
     expect(refetchVault).toHaveBeenCalledWith('vault-other', { password: 'pw' })
   })
 
-  it('subscribes loading flag to useGlobalLoading', () => {
-    renderHook(() => useVaultSwitch())
+  it('passes loading state through useGlobalLoading across protected vault switch and modal submit', async () => {
+    useGlobalLoading.mockImplementation(() => {})
 
-    expect(useGlobalLoading).toHaveBeenCalled()
+    isVaultProtected.mockResolvedValue(true)
+    const onSwitchComplete = jest.fn()
+
+    const { result } = renderHook(() => useVaultSwitch({ onSwitchComplete }))
+
     expect(useGlobalLoading.mock.calls[0][0]).toEqual(
       expect.objectContaining({ isLoading: false })
     )
+    const callsAfterMount = useGlobalLoading.mock.calls.length
+
+    await act(async () => {
+      await result.current.switchVault(vaultOther)
+    })
+
+    expect(useGlobalLoading.mock.calls.length).toBeGreaterThan(callsAfterMount)
+    expect(
+      useGlobalLoading.mock.calls[useGlobalLoading.mock.calls.length - 1][0]
+    ).toEqual(expect.objectContaining({ isLoading: false }))
+
+    const modalElement = openModal.mock.calls[0][0]
+
+    const callsAfterModalOpen = useGlobalLoading.mock.calls.length
+
+    await act(async () => {
+      await modalElement.props.onSubmit('correct-horse')
+    })
+
+    expect(onSwitchComplete).toHaveBeenCalledTimes(1)
+    expect(useGlobalLoading.mock.calls.length).toBeGreaterThan(
+      callsAfterModalOpen
+    )
+    expect(
+      useGlobalLoading.mock.calls[useGlobalLoading.mock.calls.length - 1][0]
+    ).toEqual(expect.objectContaining({ isLoading: false }))
+    // React 18 may batch consecutive setIsLoading updates inside one async continuation,
+    // so discrete true renders are not always observable in Jest; we still assert extra
+    // subscriptions after switch + submit and terminal idle state above.
   })
 })

--- a/src/hooks/useVaultSwitch.test.js
+++ b/src/hooks/useVaultSwitch.test.js
@@ -1,0 +1,170 @@
+import { renderHook, act } from '@testing-library/react-native'
+import { useVault } from '@tetherto/pearpass-lib-vault'
+
+import { useVaultSwitch } from './useVaultSwitch'
+import { useGlobalLoading } from '../context/LoadingContext'
+import { useModal } from '../context/ModalContext'
+
+jest.mock('@tetherto/pearpass-lib-vault', () => ({
+  useVault: jest.fn(),
+  useVaults: jest.fn()
+}))
+
+jest.mock('../context/ModalContext', () => ({
+  useModal: jest.fn()
+}))
+
+jest.mock('../context/LoadingContext', () => ({
+  useGlobalLoading: jest.fn()
+}))
+
+jest.mock('../containers/Modal/VaultPasswordFormModalContent', () => ({
+  VaultPasswordFormModalContent: jest.fn(() => null)
+}))
+
+describe('useVaultSwitch', () => {
+  const refetchVault = jest.fn().mockResolvedValue(undefined)
+  const isVaultProtected = jest.fn()
+  let openModal
+  let closeModal
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    refetchVault.mockResolvedValue(undefined)
+    openModal = jest.fn()
+    closeModal = jest.fn()
+
+    useVault.mockReturnValue({
+      data: { id: 'vault-active', name: 'Active Vault' },
+      isVaultProtected,
+      refetch: refetchVault
+    })
+
+    useModal.mockReturnValue({
+      openModal,
+      closeModal
+    })
+
+    useGlobalLoading.mockImplementation(() => {})
+  })
+
+  const vaultOther = { id: 'vault-other', name: 'Other Vault' }
+
+  it('calls onSameVault and skips switch when target is already active', async () => {
+    const onSameVault = jest.fn()
+    const onSwitchComplete = jest.fn()
+
+    const { result } = renderHook(() =>
+      useVaultSwitch({ onSameVault, onSwitchComplete })
+    )
+
+    await act(async () => {
+      await result.current.switchVault({
+        id: 'vault-active',
+        name: 'Active Vault'
+      })
+    })
+
+    expect(onSameVault).toHaveBeenCalledTimes(1)
+    expect(onSwitchComplete).not.toHaveBeenCalled()
+    expect(isVaultProtected).not.toHaveBeenCalled()
+    expect(refetchVault).not.toHaveBeenCalled()
+    expect(openModal).not.toHaveBeenCalled()
+  })
+
+  it('refetches and calls onSwitchComplete when vault is not protected', async () => {
+    const onSwitchComplete = jest.fn()
+    isVaultProtected.mockResolvedValue(false)
+
+    const { result } = renderHook(() => useVaultSwitch({ onSwitchComplete }))
+
+    await act(async () => {
+      await result.current.switchVault(vaultOther)
+    })
+
+    expect(isVaultProtected).toHaveBeenCalledWith('vault-other')
+    expect(refetchVault).toHaveBeenCalledWith('vault-other')
+    expect(refetchVault).toHaveBeenCalledTimes(1)
+    expect(onSwitchComplete).toHaveBeenCalledTimes(1)
+    expect(openModal).not.toHaveBeenCalled()
+  })
+
+  it('opens password modal when vault is protected', async () => {
+    isVaultProtected.mockResolvedValue(true)
+
+    const { result } = renderHook(() => useVaultSwitch())
+
+    await act(async () => {
+      await result.current.switchVault(vaultOther)
+    })
+
+    expect(openModal).toHaveBeenCalledTimes(1)
+    expect(refetchVault).not.toHaveBeenCalled()
+
+    const modalElement = openModal.mock.calls[0][0]
+    expect(modalElement.props.vault).toEqual(vaultOther)
+    expect(typeof modalElement.props.onSubmit).toBe('function')
+  })
+
+  it('refetches with password, closes modal, and completes after modal submit', async () => {
+    isVaultProtected.mockResolvedValue(true)
+    const onSwitchComplete = jest.fn()
+
+    const { result } = renderHook(() => useVaultSwitch({ onSwitchComplete }))
+
+    await act(async () => {
+      await result.current.switchVault(vaultOther)
+    })
+
+    const modalElement = openModal.mock.calls[0][0]
+
+    await act(async () => {
+      await modalElement.props.onSubmit('correct-horse')
+    })
+
+    expect(refetchVault).toHaveBeenCalledWith('vault-other', {
+      password: 'correct-horse'
+    })
+    expect(closeModal).toHaveBeenCalledTimes(1)
+    expect(onSwitchComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses injected openModal and closeModal when provided', async () => {
+    const injectedOpen = jest.fn()
+    const injectedClose = jest.fn()
+    isVaultProtected.mockResolvedValue(true)
+
+    const { result } = renderHook(() =>
+      useVaultSwitch({
+        openModal: injectedOpen,
+        closeModal: injectedClose
+      })
+    )
+
+    await act(async () => {
+      await result.current.switchVault(vaultOther)
+    })
+
+    expect(injectedOpen).toHaveBeenCalledTimes(1)
+    expect(openModal).not.toHaveBeenCalled()
+
+    const modalElement = injectedOpen.mock.calls[0][0]
+
+    await act(async () => {
+      await modalElement.props.onSubmit('pw')
+    })
+
+    expect(injectedClose).toHaveBeenCalledTimes(1)
+    expect(closeModal).not.toHaveBeenCalled()
+    expect(refetchVault).toHaveBeenCalledWith('vault-other', { password: 'pw' })
+  })
+
+  it('subscribes loading flag to useGlobalLoading', () => {
+    renderHook(() => useVaultSwitch())
+
+    expect(useGlobalLoading).toHaveBeenCalled()
+    expect(useGlobalLoading.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ isLoading: false })
+    )
+  })
+})

--- a/src/screens/Settings/Vaults2/VaultRow.jsx
+++ b/src/screens/Settings/Vaults2/VaultRow.jsx
@@ -15,7 +15,8 @@ export const VaultRow = ({
   showDivider,
   onAddMember,
   vaultActions,
-  isCurrentVault
+  isCurrentVault,
+  onClick
 }) => {
   const { t } = useLingui()
   const { theme } = useTheme()
@@ -24,6 +25,7 @@ export const VaultRow = ({
   return (
     <View>
       <ListItem
+        onClick={() => onClick?.()}
         platform="mobile"
         icon={
           <View style={styles.iconBadge}>
@@ -46,7 +48,9 @@ export const VaultRow = ({
                 onClick={onAddMember}
               />
             )}
-            <VaultActionsMenu {...vaultActions} />
+            {isCurrentVault ? (
+              <VaultActionsMenu {...vaultActions} />
+            ) : undefined}
           </View>
         }
       />

--- a/src/screens/Settings/Vaults2/VaultRow.jsx
+++ b/src/screens/Settings/Vaults2/VaultRow.jsx
@@ -25,7 +25,7 @@ export const VaultRow = ({
   return (
     <View>
       <ListItem
-        onClick={() => onClick?.()}
+        onClick={onClick}
         platform="mobile"
         icon={
           <View style={styles.iconBadge}>
@@ -39,19 +39,17 @@ export const VaultRow = ({
         title={vault?.name ?? vault?.id}
         subtitle={t`Private`}
         rightElement={
-          <View style={styles.actions}>
-            {isCurrentVault && (
+          isCurrentVault && (
+            <View style={styles.actions}>
               <Button
                 variant="tertiary"
                 size="small"
                 iconBefore={<PersonAdd color={theme.colors.colorTextPrimary} />}
                 onClick={onAddMember}
               />
-            )}
-            {isCurrentVault ? (
               <VaultActionsMenu {...vaultActions} />
-            ) : undefined}
-          </View>
+            </View>
+          )
         }
       />
 

--- a/src/screens/Settings/Vaults2/VaultRow.test.jsx
+++ b/src/screens/Settings/Vaults2/VaultRow.test.jsx
@@ -1,0 +1,153 @@
+import { i18n } from '@lingui/core'
+import { I18nProvider } from '@lingui/react'
+import { fireEvent, render } from '@testing-library/react-native'
+
+import { VaultRow } from './VaultRow'
+import messages from '../../../locales/en/messages'
+
+i18n.load('en', messages)
+i18n.activate('en')
+
+jest.mock('@tetherto/pearpass-lib-ui-kit/icons', () => {
+  const RN = require('react-native')
+  return {
+    LockOutlined: () => <RN.View testID="icon-lock" />,
+    PersonAdd: () => <RN.View testID="icon-person-add" />
+  }
+})
+
+jest.mock('./VaultActionsMenu', () => {
+  const RN = require('react-native')
+  return {
+    VaultActionsMenu: () => <RN.View testID="vault-actions-menu" />
+  }
+})
+
+jest.mock('@tetherto/pearpass-lib-ui-kit', () => {
+  const RN = require('react-native')
+  return {
+    Button: ({ onClick, children }) => (
+      <RN.TouchableOpacity testID="vault-row-add-member" onPress={onClick}>
+        <RN.Text>{children}</RN.Text>
+      </RN.TouchableOpacity>
+    ),
+    ListItem: ({
+      title,
+      subtitle,
+      onClick,
+      rightElement,
+      icon,
+      platform: _platform,
+      style: _style,
+      showDivider: _showDivider,
+      selected: _selected,
+      iconSize: _iconSize
+    }) => (
+      <RN.View>
+        <RN.Text testID="vault-row-title">{title}</RN.Text>
+        <RN.Text testID="vault-row-subtitle">{subtitle}</RN.Text>
+        {icon}
+        <RN.TouchableOpacity
+          testID="vault-row-listitem-press"
+          onPress={onClick}
+        >
+          <RN.Text>RowPress</RN.Text>
+        </RN.TouchableOpacity>
+        {rightElement}
+      </RN.View>
+    ),
+    rawTokens: {
+      spacing4: 4,
+      spacing16: 16,
+      radius8: 8
+    },
+    useTheme: () => ({
+      theme: {
+        colors: {
+          colorPrimary: '#112233',
+          colorTextPrimary: '#010203',
+          colorBorderSecondary: '#ccc'
+        }
+      }
+    })
+  }
+})
+
+const defaultVaultActions = {
+  onRename: jest.fn(),
+  onViewPairedDevices: jest.fn(),
+  onSetPassword: jest.fn(),
+  onDelete: jest.fn()
+}
+
+const renderRow = (props = {}) =>
+  render(
+    <I18nProvider i18n={i18n}>
+      <VaultRow
+        vault={{ id: 'v1', name: 'Work Vault' }}
+        showDivider={false}
+        onAddMember={jest.fn()}
+        vaultActions={defaultVaultActions}
+        isCurrentVault={false}
+        onClick={jest.fn()}
+        {...props}
+      />
+    </I18nProvider>
+  )
+
+describe('VaultRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders vault name as title', () => {
+    const { getByTestId } = renderRow({
+      vault: { id: 'v1', name: 'Personal' }
+    })
+
+    expect(getByTestId('vault-row-title').props.children).toBe('Personal')
+  })
+
+  it('falls back to vault id when name is missing', () => {
+    const { getByTestId } = renderRow({
+      vault: { id: 'only-id' }
+    })
+
+    expect(getByTestId('vault-row-title').props.children).toBe('only-id')
+  })
+
+  it('calls onClick when list row is pressed', () => {
+    const onClick = jest.fn()
+    const { getByTestId } = renderRow({ onClick })
+
+    fireEvent.press(getByTestId('vault-row-listitem-press'))
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not render add-member button or actions menu when not current vault', () => {
+    const { queryByTestId } = renderRow({ isCurrentVault: false })
+
+    expect(queryByTestId('vault-row-add-member')).toBeNull()
+    expect(queryByTestId('vault-actions-menu')).toBeNull()
+  })
+
+  it('renders add-member button and actions menu for current vault', () => {
+    const { getByTestId } = renderRow({ isCurrentVault: true })
+
+    expect(getByTestId('vault-row-add-member')).toBeTruthy()
+    expect(getByTestId('vault-actions-menu')).toBeTruthy()
+  })
+
+  it('calls onAddMember when add-member button is pressed', () => {
+    const onAddMember = jest.fn()
+    const { getByTestId } = renderRow({
+      isCurrentVault: true,
+      onAddMember
+    })
+
+    fireEvent.press(getByTestId('vault-row-add-member'))
+
+    expect(onAddMember).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/screens/Settings/Vaults2/index.jsx
+++ b/src/screens/Settings/Vaults2/index.jsx
@@ -21,6 +21,7 @@ import { VAULT_ACTION } from '../../../constants/vaultActions'
 import { BottomSheetPairedDevicesContent } from '../../../containers/BottomSheetPairedDevicesContent'
 import { ModifyVaultModalContentV2 } from '../../../containers/Modal/ModifyVaultModalContentV2'
 import { useModal } from '../../../context/ModalContext'
+import { useVaultSwitch } from '../../../hooks/useVaultSwitch'
 
 export const VaultsV2 = () => {
   const { t } = useLingui()
@@ -29,6 +30,7 @@ export const VaultsV2 = () => {
   const { openModal } = useModal()
   const [pairedDevicesOpen, setPairedDevicesOpen] = useState(false)
   const { data: currentVault, refetch: refetchVault } = useVault()
+  const { switchVault } = useVaultSwitch()
   const { data: allVaults } = useVaults()
 
   useEffect(() => {
@@ -78,6 +80,7 @@ export const VaultsV2 = () => {
       onAddMember={handleAddMember}
       isCurrentVault={isCurrentVault}
       vaultActions={buildVaultActions(vault)}
+      onClick={() => (!isCurrentVault ? switchVault(vault) : null)}
     />
   )
 
@@ -104,7 +107,7 @@ export const VaultsV2 = () => {
     >
       <PageHeader
         title={t`Your Vaults`}
-        subtitle={t`Manage your vaults, control access permissions, and take protective measures if needed.`}
+        subtitle={t`Manage your vaults. Select the vault you want to apply changes to.`}
       />
 
       <BottomSheetPairedDevicesContent


### PR DESCRIPTION
### Requirements
<!-- List the requirements for this PR -->

Header copy update: Change "Your Vaults" section text to: "Manage your vaults. Select the vault you want to apply changes to."
UI Constraint
Display action icons (Sharing and 3-dots menu) only for the currently active vault in both the navbar dropdown (left side) and in the settings → "your vaults" list
Hide all action icons for inactive vaults
Interaction: Ensure all inactive vault rows are fully clickable.
Navigation: Clicking an inactive vault must switch the active context to that vault
Experience: The vault switch must be seamless,  the user must remain on the current page/view without a reload or redirect, but the new "current vault" should be reflected to the selected one
Validation: Confirm the new active vault now displays the Sharing and 3-dots menu, while the previous vault hides them.
### Changes
<!-- Summarize the changes introduced in this PR -->
- Removed three dots menu from inactive vaults
- Made inactive vaults selectable
- Added unit tests
- Updated "your vaults" description
### Testing Notes
<!-- How did you test it? -->

### Things reviewers should pay attention to
<!-- Highlight anything specific you want reviewers to focus on -->



### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->
https://github.com/user-attachments/assets/4a70bc64-fcfa-4f8e-a580-b5c656458141

### dependencies
<!-- List any dependent work items or PRs -->
