### PR TITLE
autofill ios - touch id  & face id different

### DIFF
--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CombinedItemsFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CombinedItemsFragment.java
@@ -30,15 +30,22 @@ import com.pears.pass.R;
 import com.pears.pass.autofill.data.CredentialItem;
 import com.pears.pass.autofill.data.PearPassVaultClient;
 import com.pears.pass.autofill.data.VaultItem;
+import com.pears.pass.autofill.jobs.AddPasskeyPayload;
+import com.pears.pass.autofill.jobs.Job;
+import com.pears.pass.autofill.jobs.JobEncryption;
+import com.pears.pass.autofill.jobs.JobFileManager;
+import com.pears.pass.autofill.jobs.UpdatePasskeyPayload;
 import com.pears.pass.autofill.utils.AutofillConstants;
 import com.pears.pass.autofill.utils.SecureBufferUtils;
 import com.pears.pass.autofill.utils.SecureLog;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -366,10 +373,23 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
                 }
                 List<CredentialItem> parsed = parseCredentials(records);
 
+                // Merge pending passkey jobs in assertion mode (registration handles its own).
+                if (MODE_ASSERTION.equals(mode)) {
+                    List<CredentialItem> pending = loadPendingPasskeysFromJobs(parsed);
+                    if (!pending.isEmpty()) {
+                        Set<String> pendingIds = new HashSet<>();
+                        for (CredentialItem p : pending) pendingIds.add(p.getId());
+                        // Job version supersedes DB row for the same id.
+                        parsed.removeIf(item -> pendingIds.contains(item.getId()));
+                        parsed.addAll(pending);
+                    }
+                }
+
                 if (getActivity() == null) return;
+                final List<CredentialItem> finalParsed = parsed;
                 getActivity().runOnUiThread(() -> {
                     allCredentials.clear();
-                    allCredentials.addAll(parsed);
+                    allCredentials.addAll(finalParsed);
                     hasUserSearched = false;
                     hidePasswordPrompt();
                     applyFilter(searchInput.getText().toString());
@@ -667,5 +687,152 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
             return am.equals(bm);
         }
         return false;
+    }
+
+    /** Surfaces pending ADD/UPDATE passkey jobs as CredentialItems. */
+    @SuppressWarnings("unchecked")
+    private List<CredentialItem> loadPendingPasskeysFromJobs(List<CredentialItem> existingCredentials) {
+        List<CredentialItem> pendingPasskeys = new ArrayList<>();
+
+        if (getActivity() == null || vaultClient == null) {
+            return pendingPasskeys;
+        }
+
+        JobFileManager jobFileManager = new JobFileManager(getActivity());
+        if (!jobFileManager.jobFileExists()) {
+            return pendingPasskeys;
+        }
+
+        byte[] hashedPasswordBytes = null;
+        try {
+            Map<String, Object> masterEncryptionData = vaultClient.vaultsGet("masterEncryption").get();
+            String hashedPasswordHex = (String) masterEncryptionData.get("hashedPassword");
+            if (hashedPasswordHex == null || hashedPasswordHex.isEmpty()) {
+                SecureLog.d(TAG, "No hashed password available for job file decryption");
+                return pendingPasskeys;
+            }
+            hashedPasswordBytes = JobEncryption.hexToBytes(hashedPasswordHex);
+
+            Set<String> existingPasskeyIds = new HashSet<>();
+            for (CredentialItem item : existingCredentials) {
+                if (item.hasPasskey()) {
+                    existingPasskeyIds.add(item.getId());
+                }
+            }
+
+            List<Job> jobs = jobFileManager.readJobs(hashedPasswordBytes);
+
+            for (Job job : jobs) {
+                if (job.getStatus() != Job.JobStatus.PENDING && job.getStatus() != Job.JobStatus.IN_PROGRESS) {
+                    continue;
+                }
+
+                try {
+                    if (job.getType() == Job.JobType.ADD_PASSKEY) {
+                        AddPasskeyPayload payload = AddPasskeyPayload.fromJSON(job.getPayload());
+
+                        if (existingPasskeyIds.contains(payload.getRecordId())) {
+                            continue;
+                        }
+
+                        Map<String, Object> credentialMap = buildCredentialMapFromPayload(
+                                payload.getCredentialId(), payload.getPublicKey(), payload.getPrivateKey(),
+                                payload.getClientDataJSON(), payload.getAttestationObject(),
+                                payload.getAuthenticatorData(), payload.getAlgorithm(),
+                                payload.getTransports(), payload.getUserId()
+                        );
+
+                        List<String> websites = payload.getWebsites();
+                        if (websites == null || websites.isEmpty()) {
+                            websites = new ArrayList<>();
+                            websites.add("https://" + payload.getRpId());
+                        }
+
+                        String title = payload.getTitle() != null ? payload.getTitle() : payload.getRpName();
+
+                        pendingPasskeys.add(new CredentialItem(
+                                payload.getRecordId(), title, payload.getUserName(), "",
+                                websites, true, payload.getCreatedAt(), credentialMap,
+                                payload.getPrivateKey(), payload.getUserId(), payload.getCredentialId()
+                        ));
+
+                    } else if (job.getType() == Job.JobType.UPDATE_PASSKEY) {
+                        UpdatePasskeyPayload payload = UpdatePasskeyPayload.fromJSON(job.getPayload());
+
+                        Map<String, Object> credentialMap = buildCredentialMapFromPayload(
+                                payload.getCredentialId(), payload.getPublicKey(), payload.getPrivateKey(),
+                                payload.getClientDataJSON(), payload.getAttestationObject(),
+                                payload.getAuthenticatorData(), payload.getAlgorithm(),
+                                payload.getTransports(), payload.getUserId()
+                        );
+
+                        String title = payload.getRpName();
+                        String username = payload.getUserName();
+                        List<String> websites = new ArrayList<>();
+                        websites.add("https://" + payload.getRpId());
+
+                        for (CredentialItem existing : existingCredentials) {
+                            if (existing.getId().equals(payload.getExistingRecordId())) {
+                                title = existing.getTitle();
+                                username = existing.getUsername();
+                                if (existing.getWebsites() != null && !existing.getWebsites().isEmpty()) {
+                                    websites = existing.getWebsites();
+                                }
+                                break;
+                            }
+                        }
+
+                        pendingPasskeys.add(new CredentialItem(
+                                payload.getExistingRecordId(), title, username, "",
+                                websites, true, payload.getCreatedAt(), credentialMap,
+                                payload.getPrivateKey(), payload.getUserId(), payload.getCredentialId()
+                        ));
+                    }
+                } catch (Exception e) {
+                    SecureLog.e(TAG, "Failed to parse job payload for job " + job.getId() + ": " + e.getMessage());
+                }
+            }
+
+            SecureLog.d(TAG, "Found " + pendingPasskeys.size() + " pending passkey(s) from job queue");
+        } catch (Exception e) {
+            SecureLog.e(TAG, "Failed to read pending jobs: " + e.getMessage());
+        } finally {
+            if (hashedPasswordBytes != null) {
+                JobEncryption.secureZero(hashedPasswordBytes);
+            }
+        }
+
+        return pendingPasskeys;
+    }
+
+    /** Credential map in the vault record format. */
+    private Map<String, Object> buildCredentialMapFromPayload(
+            String credentialId, String publicKey, String privateKey,
+            String clientDataJSON, String attestationObject, String authenticatorData,
+            int algorithm, List<String> transports, String userId) {
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put("id", credentialId);
+        credentialMap.put("rawId", credentialId);
+        credentialMap.put("type", "public-key");
+        credentialMap.put("_privateKeyBuffer", privateKey);
+        credentialMap.put("_userId", userId);
+        credentialMap.put("authenticatorAttachment", "platform");
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("clientDataJSON", clientDataJSON);
+        responseMap.put("attestationObject", attestationObject);
+        responseMap.put("authenticatorData", authenticatorData);
+        responseMap.put("publicKey", publicKey);
+        responseMap.put("publicKeyAlgorithm", algorithm);
+        responseMap.put("transports", transports);
+        credentialMap.put("response", responseMap);
+
+        Map<String, Object> clientExtResults = new HashMap<>();
+        Map<String, Object> credProps = new HashMap<>();
+        credProps.put("rk", true);
+        clientExtResults.put("credProps", credProps);
+        credentialMap.put("clientExtensionResults", clientExtResults);
+
+        return credentialMap;
     }
 }

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CombinedItemsFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CombinedItemsFragment.java
@@ -375,7 +375,7 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
 
                 // Merge pending passkey jobs in assertion mode (registration handles its own).
                 if (MODE_ASSERTION.equals(mode)) {
-                    List<CredentialItem> pending = loadPendingPasskeysFromJobs(parsed);
+                    List<CredentialItem> pending = loadPendingPasskeysFromJobs(parsed, vault.getId());
                     if (!pending.isEmpty()) {
                         Set<String> pendingIds = new HashSet<>();
                         for (CredentialItem p : pending) pendingIds.add(p.getId());
@@ -426,6 +426,15 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
             out = filterInitial(allCredentials);
         } else {
             out = new ArrayList<>(allCredentials);
+        }
+
+        // Passkey assertion → keep only items with a passkey.
+        if (MODE_ASSERTION.equals(mode) && isPasskeyAssertionMode()) {
+            List<CredentialItem> passkeysOnly = new ArrayList<>();
+            for (CredentialItem c : out) {
+                if (c.hasPasskey()) passkeysOnly.add(c);
+            }
+            out = passkeysOnly;
         }
 
         if (out.isEmpty() && !allCredentials.isEmpty()) {
@@ -675,6 +684,11 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
         return parts[1] + "." + parts[0];
     }
 
+    private boolean isPasskeyAssertionMode() {
+        return getActivity() instanceof AuthenticationActivity
+                && ((AuthenticationActivity) getActivity()).isPasskeyAssertionMode();
+    }
+
     private boolean domainsMatch(String a, String b) {
         if (a == null || b == null) return false;
         if (a.equals(b)) return true;
@@ -689,9 +703,9 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
         return false;
     }
 
-    /** Surfaces pending ADD/UPDATE passkey jobs as CredentialItems. */
+    /** Surfaces pending ADD/UPDATE passkey jobs scoped to the current vault. */
     @SuppressWarnings("unchecked")
-    private List<CredentialItem> loadPendingPasskeysFromJobs(List<CredentialItem> existingCredentials) {
+    private List<CredentialItem> loadPendingPasskeysFromJobs(List<CredentialItem> existingCredentials, String currentVaultId) {
         List<CredentialItem> pendingPasskeys = new ArrayList<>();
 
         if (getActivity() == null || vaultClient == null) {
@@ -724,6 +738,11 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
 
             for (Job job : jobs) {
                 if (job.getStatus() != Job.JobStatus.PENDING && job.getStatus() != Job.JobStatus.IN_PROGRESS) {
+                    continue;
+                }
+                // Vault scope — drop jobs queued for a different vault so they
+                // don't leak into the active vault's credentials list.
+                if (currentVaultId != null && !currentVaultId.equals(job.getVaultId())) {
                     continue;
                 }
 

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CredentialsListFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CredentialsListFragment.java
@@ -174,6 +174,17 @@ public class CredentialsListFragment extends BaseAutofillFragment {
         }
         // If hasUserSearched is true and query is empty, show all credentials (no filtering)
 
+        // Passkey assertion → keep only items with a passkey.
+        boolean passkeyMode = (getActivity() instanceof AuthenticationActivity)
+                && ((AuthenticationActivity) getActivity()).isPasskeyAssertionMode();
+        if (passkeyMode) {
+            List<CredentialItem> passkeysOnly = new ArrayList<>();
+            for (CredentialItem c : filtered) {
+                if (c.hasPasskey()) passkeysOnly.add(c);
+            }
+            filtered = passkeysOnly;
+        }
+
         return filtered;
     }
 
@@ -359,6 +370,10 @@ public class CredentialsListFragment extends BaseAutofillFragment {
 
             for (Job job : jobs) {
                 if (job.getStatus() != Job.JobStatus.PENDING && job.getStatus() != Job.JobStatus.IN_PROGRESS) {
+                    continue;
+                }
+                // Vault scope — only show jobs queued for the active vault.
+                if (vaultId != null && !vaultId.equals(job.getVaultId())) {
                     continue;
                 }
 

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/MasterPasswordFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/MasterPasswordFragment.java
@@ -33,6 +33,8 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
     private ImageView togglePasswordVisibility;
     private boolean isAuthenticatingBiometric = false;
     private boolean isPasswordVisible = false;
+    // V2 spinner overlay shown over Continue while auth is in flight.
+    private android.widget.ProgressBar continueProgress;
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -106,7 +108,8 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
         passwordInput = view.findViewById(R.id.ppPasswordEdit);
         unlockButton = view.findViewById(R.id.masterPwdContinue);
         togglePasswordVisibility = view.findViewById(R.id.ppPasswordToggle);
-        biometricButton = null;
+        biometricButton = view.findViewById(R.id.masterPwdBiometricButton);
+        continueProgress = view.findViewById(R.id.masterPwdContinueProgress);
 
         TextView passwordLabel = view.findViewById(R.id.ppPasswordLabel);
         if (passwordLabel != null) passwordLabel.setText("Password");
@@ -120,7 +123,11 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
         }
 
         TextView sheetTitle = view.findViewById(R.id.ppHeaderTitle);
-        if (sheetTitle != null) sheetTitle.setText("Add a passkey");
+        if (sheetTitle != null) {
+            // Sign in for assertion, Add a passkey for registration.
+            String title = (getActivity() instanceof AuthenticationActivity) ? "Sign in" : "Add a passkey";
+            sheetTitle.setText(title);
+        }
 
         unlockButton.setOnClickListener(v -> {
             String password = passwordInput.getText().toString();
@@ -132,6 +139,7 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
         });
 
         setupPasswordVisibilityToggle();
+        setupBiometricButton();
 
         return view;
     }
@@ -145,9 +153,14 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
             return;
         }
 
-        // Disable the unlock button while authenticating
+        // V2 hides "Continue" + shows spinner; V1 swaps to "Unlocking...".
         unlockButton.setEnabled(false);
-        unlockButton.setText("Unlocking...");
+        if (getResources().getInteger(R.integer.design_version) == 2) {
+            unlockButton.setText("");
+            if (continueProgress != null) continueProgress.setVisibility(View.VISIBLE);
+        } else {
+            unlockButton.setText("Unlocking...");
+        }
 
         // Convert password to byte array for secure handling
         byte[] passwordBuffer = com.pears.pass.autofill.utils.SecureBufferUtils.stringToBuffer(password);
@@ -178,9 +191,8 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
                     SecureLog.w("MasterPasswordFragment", "Could not get master encryption for resume: " + e.getMessage());
                 }
 
-                // Authentication successful
+                // Authentication successful — silent navigation.
                 getActivity().runOnUiThread(() -> {
-                    Toast.makeText(getContext(), "Authentication successful", Toast.LENGTH_SHORT).show();
                     if (navigationListener != null) {
                         navigationListener.navigateToVaultSelection();
                     }
@@ -192,7 +204,12 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
                 getActivity().runOnUiThread(() -> {
                     Toast.makeText(getContext(), "Invalid master password", Toast.LENGTH_SHORT).show();
                     unlockButton.setEnabled(true);
-                    unlockButton.setText("Unlock");
+                    if (getResources().getInteger(R.integer.design_version) == 2) {
+                        unlockButton.setText("Continue");
+                        if (continueProgress != null) continueProgress.setVisibility(View.GONE);
+                    } else {
+                        unlockButton.setText("Unlock");
+                    }
                     passwordInput.setText("");
                 });
             } finally {
@@ -266,19 +283,26 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
                 ", canUse: " + canUse);
 
             if (isSupported && isEnabled && canUse) {
-                // Show biometric button
                 biometricButton.setVisibility(View.VISIBLE);
 
-                biometricButton.setText("Use Biometric");
+                // V2 retry link picks "Fingerprint" when device advertises one.
+                if (getResources().getInteger(R.integer.design_version) == 2) {
+                    boolean hasFingerprint = getContext() != null
+                            && getContext().getPackageManager().hasSystemFeature(
+                                    android.content.pm.PackageManager.FEATURE_FINGERPRINT);
+                    biometricButton.setText(hasFingerprint
+                            ? "Try again with Fingerprint"
+                            : "Try again with Biometrics");
+                } else {
+                    biometricButton.setText("Use Biometric");
+                }
 
-                // Set click listener for biometric authentication
                 biometricButton.setOnClickListener(v -> {
                     if (!isAuthenticatingBiometric) {
                         handleBiometricLogin();
                     }
                 });
             } else {
-                // Hide biometric button if not available
                 biometricButton.setVisibility(View.GONE);
             }
         }
@@ -377,7 +401,6 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
 
                 getActivity().runOnUiThread(() -> {
                     isAuthenticatingBiometric = false;
-                    Toast.makeText(getContext(), "Authentication successful", Toast.LENGTH_SHORT).show();
                     if (navigationListener != null) {
                         navigationListener.navigateToVaultSelection();
                     }

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/PasskeyFormFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/PasskeyFormFragment.java
@@ -51,7 +51,7 @@ public class PasskeyFormFragment extends Fragment {
 
     private EditText titleInput;
     private EditText usernameInput;
-    private EditText websiteInput;
+    private EditText websiteInput; // V1 only — V2 uses websiteInputs list
     private EditText commentInput;
     private TextView titleError;
     private TextView websiteError;
@@ -63,6 +63,14 @@ public class PasskeyFormFragment extends Fragment {
     private Button saveButton;
     private Button uploadFileButton;
     private LinearLayout attachmentsContainer;
+
+    // V2 multi-website rows; V1 keeps the single websiteInput.
+    private LinearLayout websitesRowContainer;
+    private View addWebsiteButton;
+    private final List<EditText> websiteInputs = new ArrayList<>();
+
+    // V2 spinner overlay shown over Save while the passkey is being written.
+    private android.widget.ProgressBar saveProgress;
 
     private static final String STATE_SELECTED_FOLDER = "selected_folder";
     private static final String STATE_PASSKEY_CREATED_AT = "passkey_created_at";
@@ -175,12 +183,9 @@ public class PasskeyFormFragment extends Fragment {
         passkeyDateText.setCursorVisible(false);
         passkeyDateText.setKeyListener(null);
 
-        View websiteField = view.findViewById(R.id.formWebsiteField);
-        websiteInput = websiteField.findViewById(R.id.ppInputEdit);
-        setInputFieldLabel(websiteField, "Website");
-        websiteInput.setHint("https://");
-        websiteInput.setInputType(android.text.InputType.TYPE_CLASS_TEXT
-                | android.text.InputType.TYPE_TEXT_VARIATION_URI);
+        // V2: unified websites card; rows added via addWebsiteRow.
+        websitesRowContainer = view.findViewById(R.id.formWebsitesRowContainer);
+        addWebsiteButton = view.findViewById(R.id.formAddWebsiteButton);
         websiteError = view.findViewById(R.id.formWebsiteError);
 
         View commentField = view.findViewById(R.id.formCommentField);
@@ -196,16 +201,13 @@ public class PasskeyFormFragment extends Fragment {
         if (folderLeading != null) folderLeading.setVisibility(View.GONE);
         folderRow.setOnClickListener(v -> showFolderPicker());
 
-        // attachments + upload file hidden; re-enable via edit flow later
-        // attachmentsContainer = view.findViewById(R.id.formAttachmentsContainer);
-        // uploadFileButton = view.findViewById(R.id.formUploadFileButton);
-        attachmentsContainer = null;
-        uploadFileButton = null;
+        attachmentsContainer = view.findViewById(R.id.formAttachmentsContainer);
+        uploadFileButton = view.findViewById(R.id.formUploadFileButton);
 
         saveError = view.findViewById(R.id.formSaveError);
-        // fileSizeError = view.findViewById(R.id.formFileSizeError);
-        fileSizeError = null;
+        fileSizeError = view.findViewById(R.id.formFileSizeError);
         saveButton = view.findViewById(R.id.formSaveButton);
+        saveProgress = view.findViewById(R.id.formSaveProgress);
 
         View discard = view.findViewById(R.id.formDiscardButton);
         cancelButton = null;
@@ -244,6 +246,9 @@ public class PasskeyFormFragment extends Fragment {
         // Always use current time since this is a new passkey being created
         passkeyCreatedAt = System.currentTimeMillis();
 
+        boolean isV2 = getResources().getInteger(R.integer.design_version) == 2;
+        List<String> initialWebsites = new ArrayList<>();
+
         if (existingRecord != null) {
             // Pre-populate from existing record
             Map<String, Object> data = null;
@@ -256,8 +261,10 @@ public class PasskeyFormFragment extends Fragment {
                 usernameInput.setText(data.get("username") != null ? (String) data.get("username") : "");
 
                 Object websitesObj = data.get("websites");
-                if (websitesObj instanceof List && !((List<?>) websitesObj).isEmpty()) {
-                    websiteInput.setText((String) ((List<?>) websitesObj).get(0));
+                if (websitesObj instanceof List) {
+                    for (Object item : (List<?>) websitesObj) {
+                        if (item instanceof String) initialWebsites.add((String) item);
+                    }
                 }
 
                 commentInput.setText(data.get("note") != null ? (String) data.get("note") : "");
@@ -282,7 +289,17 @@ public class PasskeyFormFragment extends Fragment {
             // Pre-populate from passkey request
             titleInput.setText(activity.getRpName());
             usernameInput.setText(activity.getUserName());
-            websiteInput.setText("https://" + activity.getRpId());
+            initialWebsites.add("https://" + activity.getRpId());
+        }
+
+        if (isV2) {
+            if (initialWebsites.isEmpty()) {
+                addWebsiteRow("");
+            } else {
+                for (String w : initialWebsites) addWebsiteRow(w);
+            }
+        } else if (websiteInput != null && !initialWebsites.isEmpty()) {
+            websiteInput.setText(initialWebsites.get(0));
         }
 
         // Update folder display
@@ -328,21 +345,53 @@ public class PasskeyFormFragment extends Fragment {
     }
 
     /**
-     * Cancel/folder/discard are wired in bindV2Views; this handles the rest
+     * Cancel/folder/discard are wired in bindV2Views; this handles the rest.
+     * Website TextWatcher is attached per-row by addWebsiteRow.
      */
     private void setupListenersV2() {
         titleInput.addTextChangedListener(new SimpleTextWatcher(() -> {
             if (titleError != null) titleError.setVisibility(View.GONE);
         }));
 
-        websiteInput.addTextChangedListener(new SimpleTextWatcher(() -> {
-            if (websiteError != null) websiteError.setVisibility(View.GONE);
-        }));
+        if (addWebsiteButton != null) {
+            addWebsiteButton.setOnClickListener(v -> {
+                if (isSaving) return;
+                addWebsiteRow("");
+            });
+        }
 
         saveButton.setOnClickListener(v -> handleSave());
 
-        // Upload file hidden in V2.
-        // uploadFileButton.setOnClickListener(v -> openFilePicker());
+        if (uploadFileButton != null) {
+            uploadFileButton.setOnClickListener(v -> openFilePicker());
+        }
+    }
+
+    /** Appends a website row + divider (between-rows) to the unified card. */
+    private void addWebsiteRow(String initialText) {
+        if (websitesRowContainer == null || getContext() == null) return;
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+
+        // Divider between rows (skip before first).
+        if (!websiteInputs.isEmpty()) {
+            View divider = new View(getContext());
+            divider.setLayoutParams(new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    Math.max(1, (int) getResources().getDisplayMetrics().density)));
+            divider.setBackgroundColor(0x14FFFFFF);
+            websitesRowContainer.addView(divider);
+        }
+
+        View row = inflater.inflate(R.layout.include_pp_website_row_v2, websitesRowContainer, false);
+        EditText edit = row.findViewById(R.id.ppWebsiteRowEdit);
+        if (initialText != null) edit.setText(initialText);
+        edit.addTextChangedListener(new SimpleTextWatcher(() -> {
+            if (websiteError != null) websiteError.setVisibility(View.GONE);
+        }));
+
+        websitesRowContainer.addView(row);
+        websiteInputs.add(edit);
     }
 
     private void showFolderPicker() {
@@ -538,14 +587,26 @@ public class PasskeyFormFragment extends Fragment {
             isValid = false;
         }
 
-        // Website optional but must be valid if provided
-        String website = websiteInput.getText().toString().trim();
-        if (!website.isEmpty()) {
-            String urlString = addHttps(website);
+        // V2 collects from every row; V1 falls back to single websiteInput.
+        List<String> entriesToCheck = new ArrayList<>();
+        if (!websiteInputs.isEmpty()) {
+            for (EditText e : websiteInputs) {
+                entriesToCheck.add(e.getText().toString().trim());
+            }
+        } else if (websiteInput != null) {
+            entriesToCheck.add(websiteInput.getText().toString().trim());
+        }
+
+        for (String entry : entriesToCheck) {
+            if (entry.isEmpty()) continue;
+            String urlString = addHttps(entry);
             if (!urlString.contains(".")) {
-                websiteError.setText("Wrong format of website");
-                websiteError.setVisibility(View.VISIBLE);
+                if (websiteError != null) {
+                    websiteError.setText("Wrong format of website");
+                    websiteError.setVisibility(View.VISIBLE);
+                }
                 isValid = false;
+                break;
             }
         }
 
@@ -558,16 +619,27 @@ public class PasskeyFormFragment extends Fragment {
 
         isSaving = true;
         saveButton.setEnabled(false);
+        // V2: hide button label, show spinner overlay.
+        if (saveProgress != null) {
+            saveButton.setText("");
+            saveProgress.setVisibility(View.VISIBLE);
+        }
         if (uploadFileButton != null) uploadFileButton.setEnabled(false);
 
         String title = titleInput.getText().toString().trim();
         String username = usernameInput.getText().toString();
-        String website = websiteInput.getText().toString().trim();
         String comment = commentInput.getText().toString();
 
+        // Drop empty rows + normalize each via addHttps before save.
         List<String> websites = new ArrayList<>();
-        if (!website.isEmpty()) {
-            websites.add(addHttps(website));
+        if (!websiteInputs.isEmpty()) {
+            for (EditText e : websiteInputs) {
+                String w = e.getText().toString().trim();
+                if (!w.isEmpty()) websites.add(addHttps(w));
+            }
+        } else if (websiteInput != null) {
+            String w = websiteInput.getText().toString().trim();
+            if (!w.isEmpty()) websites.add(addHttps(w));
         }
 
         String existingRecordId = null;

--- a/plugins/expo-autofill-plugin/android-template/res/layout/fragment_master_password_v2.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/layout/fragment_master_password_v2.xml
@@ -52,6 +52,24 @@
             <include
                 android:id="@+id/masterPwdField"
                 layout="@layout/include_pp_password_field_v2" />
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <!-- Biometric retry link; wording tracks the device's biometry type. -->
+            <TextView
+                android:id="@+id/masterPwdBiometricButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/pp_v2_spacing_s16"
+                android:gravity="center"
+                android:textAppearance="@style/TextAppearance.PearPass.V2.Label"
+                android:textColor="@color/pp_v2_primary"
+                android:visibility="gone"
+                tools:text="Try again with Face ID"
+                tools:visibility="visible" />
         </LinearLayout>
 
         
@@ -60,16 +78,30 @@
             android:layout_height="1dp"
             android:background="@color/pp_v2_border_primary" />
 
-        
-        <Button
-            android:id="@+id/masterPwdContinue"
-            style="@style/Button.PearPass.V2.Primary"
+        <!-- Continue button + spinner overlay. -->
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/pp_v2_spacing_s16"
             android:layout_marginEnd="@dimen/pp_v2_spacing_s16"
             android:layout_marginTop="@dimen/pp_v2_spacing_s16"
-            android:layout_marginBottom="@dimen/pp_v2_spacing_s32"
-            android:text="Continue" />
+            android:layout_marginBottom="@dimen/pp_v2_spacing_s32">
+
+            <Button
+                android:id="@+id/masterPwdContinue"
+                style="@style/Button.PearPass.V2.Primary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Continue" />
+
+            <ProgressBar
+                android:id="@+id/masterPwdContinueProgress"
+                style="?android:attr/progressBarStyleSmall"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:layout_gravity="center"
+                android:indeterminateTint="@color/pp_v2_on_primary"
+                android:visibility="gone" />
+        </FrameLayout>
     </LinearLayout>
 </LinearLayout>

--- a/plugins/expo-autofill-plugin/android-template/res/layout/fragment_passkey_form_v2.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/layout/fragment_passkey_form_v2.xml
@@ -58,8 +58,8 @@
                 android:layout_marginTop="@dimen/pp_v2_spacing_s24"
                 android:layout_marginBottom="@dimen/pp_v2_spacing_s8"
                 android:text="Credentials"
-                android:textAppearance="@style/TextAppearance.PearPass.V2.Label"
-                android:textColor="@color/pp_v2_text_secondary" />
+                android:textAppearance="@style/TextAppearance.PearPass.V2.Caption"
+                android:textColor="@color/pp_v2_text_primary" />
 
             <include
                 android:id="@+id/formUsernameField"
@@ -80,12 +80,59 @@
                 android:layout_marginTop="@dimen/pp_v2_spacing_s24"
                 android:layout_marginBottom="@dimen/pp_v2_spacing_s8"
                 android:text="Details"
-                android:textAppearance="@style/TextAppearance.PearPass.V2.Label"
-                android:textColor="@color/pp_v2_text_secondary" />
+                android:textAppearance="@style/TextAppearance.PearPass.V2.Caption"
+                android:textColor="@color/pp_v2_text_primary" />
 
-            <include
-                android:id="@+id/formWebsiteField"
-                layout="@layout/include_pp_input_field_v2" />
+            <!-- Unified websites card. Rows added by PasskeyFormFragment. -->
+            <LinearLayout
+                android:id="@+id/formWebsitesCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:addStatesFromChildren="true"
+                android:background="@drawable/pp_v2_input_bg"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/formWebsitesRowContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical" />
+
+                <!-- Divider above "+ Add Another Website". -->
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="#14FFFFFF" />
+
+                <LinearLayout
+                    android:id="@+id/formAddWebsiteButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="@dimen/pp_v2_spacing_s12"
+                    android:paddingEnd="@dimen/pp_v2_spacing_s12"
+                    android:paddingTop="@dimen/pp_v2_spacing_s12"
+                    android:paddingBottom="@dimen/pp_v2_spacing_s12">
+
+                    <ImageView
+                        android:layout_width="14dp"
+                        android:layout_height="14dp"
+                        android:layout_marginEnd="@dimen/pp_v2_spacing_s4"
+                        android:contentDescription="@null"
+                        android:src="@drawable/pp_v2_ic_plus"
+                        app:tint="@color/pp_v2_primary"
+                        tools:ignore="ContentDescription" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Add Another Website"
+                        android:textAppearance="@style/TextAppearance.PearPass.V2.LabelEmphasized"
+                        android:textColor="@color/pp_v2_primary" />
+                </LinearLayout>
+            </LinearLayout>
 
             <TextView
                 android:id="@+id/formWebsiteError"
@@ -115,7 +162,6 @@
                 android:id="@+id/formFolderSelector"
                 layout="@layout/include_pp_list_item_v2" />
 
-            <!-- Attachments + upload file temporarily hidden per team decision
             <LinearLayout
                 android:id="@+id/formAttachmentsContainer"
                 android:layout_width="match_parent"
@@ -136,12 +182,11 @@
 
             <Button
                 android:id="@+id/formUploadFileButton"
-                style="@style/Button.PearPass.V2.Tertiary"
+                style="@style/Button.PearPass.V2.Secondary"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/pp_v2_spacing_s12"
                 android:text="Upload File" />
-            -->
         </LinearLayout>
     </ScrollView>
 
@@ -173,12 +218,27 @@
             android:textColor="@color/pp_v2_surface_error"
             android:visibility="gone" />
 
-        <Button
-            android:id="@+id/formSaveButton"
-            style="@style/Button.PearPass.V2.Primary"
+        <!-- Save button + spinner overlay. -->
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Save &amp; Add Login" />
+            android:layout_height="wrap_content">
+
+            <Button
+                android:id="@+id/formSaveButton"
+                style="@style/Button.PearPass.V2.Primary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Save &amp; Add Login" />
+
+            <ProgressBar
+                android:id="@+id/formSaveProgress"
+                style="?android:attr/progressBarStyleSmall"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:layout_gravity="center"
+                android:indeterminateTint="@color/pp_v2_on_primary"
+                android:visibility="gone" />
+        </FrameLayout>
 
         <Button
             android:id="@+id/formDiscardButton"

--- a/plugins/expo-autofill-plugin/android-template/res/layout/include_pp_input_field_v2.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/layout/include_pp_input_field_v2.xml
@@ -5,6 +5,7 @@
     android:id="@+id/ppInputContainer"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:addStatesFromChildren="true"
     android:background="@drawable/pp_v2_input_bg"
     android:gravity="center_vertical"
     android:orientation="horizontal"
@@ -23,8 +24,8 @@
             android:id="@+id/ppInputLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.PearPass.V2.Label"
-            android:textColor="@color/pp_v2_text_secondary"
+            android:textAppearance="@style/TextAppearance.PearPass.V2.Caption"
+            android:textColor="@color/pp_v2_text_primary"
             tools:text="Email" />
 
         <EditText
@@ -39,8 +40,8 @@
             android:textColor="@color/pp_v2_text_primary"
             android:textColorHint="@color/pp_v2_text_secondary"
             android:textCursorDrawable="@null"
-            android:textSize="@dimen/pp_v2_font_s16"
-            android:textStyle="normal" />
+            android:textSize="@dimen/pp_v2_font_s14"
+            android:textFontWeight="500" />
     </LinearLayout>
 
     <ImageView

--- a/plugins/expo-autofill-plugin/android-template/res/layout/include_pp_password_field_v2.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/layout/include_pp_password_field_v2.xml
@@ -5,6 +5,7 @@
     android:id="@+id/ppPasswordContainer"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:addStatesFromChildren="true"
     android:background="@drawable/pp_v2_input_bg"
     android:gravity="center_vertical"
     android:orientation="horizontal"

--- a/plugins/expo-autofill-plugin/android-template/res/layout/include_pp_website_row_v2.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/layout/include_pp_website_row_v2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Single website row inside the unified websites card. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/ppWebsiteRowRoot"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/pp_v2_spacing_s12"
+    android:paddingEnd="@dimen/pp_v2_spacing_s12"
+    android:paddingTop="@dimen/pp_v2_spacing_s12"
+    android:paddingBottom="@dimen/pp_v2_spacing_s12">
+
+    <TextView
+        android:id="@+id/ppWebsiteRowLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Website"
+        android:textAppearance="@style/TextAppearance.PearPass.V2.Caption"
+        android:textColor="@color/pp_v2_text_primary" />
+
+    <EditText
+        android:id="@+id/ppWebsiteRowEdit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/pp_v2_spacing_s4"
+        android:background="@null"
+        android:fontFamily="@font/pp_v2_inter"
+        android:hint="Enter Website"
+        android:inputType="textUri"
+        android:minHeight="0dp"
+        android:padding="0dp"
+        android:textColor="@color/pp_v2_text_primary"
+        android:textColorHint="@color/pp_v2_text_secondary"
+        android:textCursorDrawable="@null"
+        android:textFontWeight="500"
+        android:textSize="@dimen/pp_v2_font_s14"
+        tools:text="https://example.com" />
+</LinearLayout>

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/Base.lproj/Localizable.strings
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/Base.lproj/Localizable.strings
@@ -135,4 +135,12 @@
 /* V2 — accessibility labels */
 "Close" = "Close";
 "Back" = "Back";
-"Toggle password visibility" = "Toggle password visibility";"Try again with Face ID" = "Try again with Face ID";
+"Toggle password visibility" = "Toggle password visibility";
+
+/* V2 — biometric retry link */
+"Try again with Face ID" = "Try again with Face ID";
+"Try again with Touch ID" = "Try again with Touch ID";
+"Try again with Biometrics" = "Try again with Biometrics";
+
+/* V2 — passkey form validation */
+"Wrong format of website" = "Wrong format of website";

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/V2HostView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/V2HostView.swift
@@ -68,9 +68,7 @@ struct V2HostView: View {
     @State private var loadedFolders: [String] = []
     @State private var formComment: String = ""
     @State private var formSaveError: String?
-    /// Inline error rendered under the websites card when one of the entries
-    /// fails URL validation on save. Cleared at the start of each save and
-    /// when the form is reopened (mirrors V1 PasskeyFormView.websiteError).
+    /// Inline error under the websites card on URL validation failure.
     @State private var formWebsiteError: String? = nil
     @State private var isSavingPasskey: Bool = false
     /// Set when the user picks an existing matching record on registration —
@@ -673,9 +671,7 @@ struct V2HostView: View {
             return
         }
 
-        // Validate website entries (mirrors V1 PasskeyFormView.validate).
-        // Empty rows are skipped — they get filtered out before save anyway.
-        // First malformed entry blocks the save and surfaces the inline error.
+        // Validate website entries — first malformed one blocks save.
         formWebsiteError = nil
         let trimmedWebsites = formWebsites.map { $0.trimmingCharacters(in: .whitespaces) }
         for entry in trimmedWebsites where !entry.isEmpty {
@@ -699,11 +695,7 @@ struct V2HostView: View {
                     throw PasskeyJobError.noHashedPassword
                 }
 
-                // 3. Build form data — websites array filtered for empties so
-                //    placeholder rows don't end up in the saved record, then
-                //    each surviving entry is normalized via addHttps so bare
-                //    hostnames pick up a scheme (V1 parity). Folder is the
-                //    user's pick from the form (if any).
+                // 3. Build form data — drop empty rows, normalize via addHttps.
                 let websites = trimmedWebsites
                     .filter { !$0.isEmpty }
                     .map { self.addHttps($0) }
@@ -1225,10 +1217,7 @@ struct V2HostView: View {
         return s
     }
 
-    /// Mirrors V1 PasskeyFormView.addHttps — lowercases the input and prepends
-    /// "https://" when it lacks an http/https scheme. Used both for save-time
-    /// validation (URL parsing wants a scheme to find a host) and for the
-    /// final stored value so bare hostnames don't pollute the record.
+    /// Lowercases + prepends `https://` when no scheme is present.
     private func addHttps(_ urlString: String) -> String {
         let lower = urlString.lowercased()
         if lower.hasPrefix("http://") || lower.hasPrefix("https://") {

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/V2HostView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/V2HostView.swift
@@ -855,6 +855,7 @@ struct V2HostView: View {
                 let pending = await loadPendingPasskeysFromJobs(
                     vaultClient: client,
                     existingRecords: records,
+                    currentVaultId: viewModel.selectedVault?.id,
                     filterRpId: mode == .registration ? registrationContext?.rpId : nil,
                     filterUserName: mode == .registration ? registrationContext?.userName : nil
                 )
@@ -943,6 +944,7 @@ struct V2HostView: View {
     private func loadPendingPasskeysFromJobs(
         vaultClient: PearPassVaultClient,
         existingRecords: [VaultRecord],
+        currentVaultId: String?,
         filterRpId: String? = nil,
         filterUserName: String? = nil
     ) async -> [VaultRecord] {
@@ -982,6 +984,10 @@ struct V2HostView: View {
             var pending: [VaultRecord] = []
 
             for job in jobs where job.status == .pending || job.status == .inProgress {
+                // Vault scope — drop jobs queued for a different vault.
+                if let currentVaultId = currentVaultId, job.vaultId != currentVaultId {
+                    continue
+                }
                 switch job.payload {
                 case .addPasskey(let payload):
                     guard !existingPasskeyIds.contains(payload.recordId) else { continue }

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/V2HostView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/V2HostView.swift
@@ -68,6 +68,10 @@ struct V2HostView: View {
     @State private var loadedFolders: [String] = []
     @State private var formComment: String = ""
     @State private var formSaveError: String?
+    /// Inline error rendered under the websites card when one of the entries
+    /// fails URL validation on save. Cleared at the start of each save and
+    /// when the form is reopened (mirrors V1 PasskeyFormView.websiteError).
+    @State private var formWebsiteError: String? = nil
     @State private var isSavingPasskey: Bool = false
     /// Set when the user picks an existing matching record on registration —
     /// causes save to fire UPDATE_PASSKEY (or refresh a pending ADD) instead
@@ -307,6 +311,7 @@ struct V2HostView: View {
             attachments: $formAttachments,
             existingAttachments: $formExistingAttachments,
             fileSizeError: $formFileSizeError,
+            websiteError: $formWebsiteError,
             saveError: formSaveError,
             isSaving: isSavingPasskey,
             onBack: { showPasskeyForm = false },
@@ -623,6 +628,7 @@ struct V2HostView: View {
         formatter.dateStyle = .medium
         formPasskeyDate = formatter.string(from: Date())
         formSaveError = nil
+        formWebsiteError = nil
         showPasskeyForm = true
     }
 
@@ -648,6 +654,7 @@ struct V2HostView: View {
         formatter.dateStyle = .medium
         formPasskeyDate = formatter.string(from: Date())
         formSaveError = nil
+        formWebsiteError = nil
         showPasskeyForm = true
     }
 
@@ -666,6 +673,19 @@ struct V2HostView: View {
             return
         }
 
+        // Validate website entries (mirrors V1 PasskeyFormView.validate).
+        // Empty rows are skipped — they get filtered out before save anyway.
+        // First malformed entry blocks the save and surfaces the inline error.
+        formWebsiteError = nil
+        let trimmedWebsites = formWebsites.map { $0.trimmingCharacters(in: .whitespaces) }
+        for entry in trimmedWebsites where !entry.isEmpty {
+            let candidate = addHttps(entry)
+            guard let host = URL(string: candidate)?.host, host.contains(".") else {
+                formWebsiteError = NSLocalizedString("Wrong format of website", comment: "V2 website validation error")
+                return
+            }
+        }
+
         isSavingPasskey = true
         formSaveError = nil
 
@@ -680,11 +700,13 @@ struct V2HostView: View {
                 }
 
                 // 3. Build form data — websites array filtered for empties so
-                //    placeholder rows don't end up in the saved record. Folder
-                //    is the user's pick from the form (if any).
-                let websites = formWebsites
-                    .map { $0.trimmingCharacters(in: .whitespaces) }
+                //    placeholder rows don't end up in the saved record, then
+                //    each surviving entry is normalized via addHttps so bare
+                //    hostnames pick up a scheme (V1 parity). Folder is the
+                //    user's pick from the form (if any).
+                let websites = trimmedWebsites
                     .filter { !$0.isEmpty }
+                    .map { self.addHttps($0) }
                 let formData = PasskeyFormData(
                     title: formTitleText,
                     username: formUsername,
@@ -1201,6 +1223,18 @@ struct V2HostView: View {
         if let colon = s.firstIndex(of: ":") { s = String(s[..<colon]) }
         if s.hasPrefix("www.") { s = String(s.dropFirst(4)) }
         return s
+    }
+
+    /// Mirrors V1 PasskeyFormView.addHttps — lowercases the input and prepends
+    /// "https://" when it lacks an http/https scheme. Used both for save-time
+    /// validation (URL parsing wants a scheme to find a host) and for the
+    /// final stored value so bare hostnames don't pollute the record.
+    private func addHttps(_ urlString: String) -> String {
+        let lower = urlString.lowercased()
+        if lower.hasPrefix("http://") || lower.hasPrefix("https://") {
+            return lower
+        }
+        return "https://\(lower)"
     }
 
     private func initials(for title: String?) -> String {

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/Views/MasterPasswordV2View.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/Views/MasterPasswordV2View.swift
@@ -52,6 +52,21 @@ struct MasterPasswordV2View: View {
         }
     }
 
+    /// Inline retry link that sits below the master-password field. Wording
+    /// nudges the user that biometric is the same auth path they were prompted
+    /// with on screen open ("again"), and the suffix tracks the device's
+    /// actual biometry type so Touch ID hardware doesn't read "Face ID".
+    private var biometricRetryTitle: String {
+        switch KeychainHelper.shared.getBiometricType() {
+        case .faceID:
+            return NSLocalizedString("Try again with Face ID", comment: "V2 biometric retry link — Face ID")
+        case .touchID:
+            return NSLocalizedString("Try again with Touch ID", comment: "V2 biometric retry link — Touch ID")
+        default:
+            return NSLocalizedString("Try again with Biometrics", comment: "V2 biometric retry link — generic")
+        }
+    }
+
     private var biometricIconName: String {
         switch KeychainHelper.shared.getBiometricType() {
         case .faceID: return "faceid"
@@ -112,7 +127,7 @@ struct MasterPasswordV2View: View {
                         // password input has the visual weight of the screen.
                         if showBiometricButton {
                             Button(action: onFaceIDLogin) {
-                                Text(NSLocalizedString("Try with Face ID", comment: "V2 biometric retry link"))
+                                Text(biometricRetryTitle)
                                     .font(Font.custom(PPFontFamily.inter, size: PPFontSizes.s14))
                                     .foregroundColor(PPColors.primary)
                                     .underline()

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/Views/MasterPasswordV2View.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/Views/MasterPasswordV2View.swift
@@ -52,10 +52,7 @@ struct MasterPasswordV2View: View {
         }
     }
 
-    /// Inline retry link that sits below the master-password field. Wording
-    /// nudges the user that biometric is the same auth path they were prompted
-    /// with on screen open ("again"), and the suffix tracks the device's
-    /// actual biometry type so Touch ID hardware doesn't read "Face ID".
+    /// Suffix tracks device biometry type so Touch ID hardware doesn't read "Face ID".
     private var biometricRetryTitle: String {
         switch KeychainHelper.shared.getBiometricType() {
         case .faceID:
@@ -75,10 +72,9 @@ struct MasterPasswordV2View: View {
         }
     }
 
+    /// Static label — spinner replaces it during isLoading.
     private var continueButtonTitle: String {
-        isAuthenticating
-            ? NSLocalizedString("Authenticating...", comment: "Authentication in progress")
-            : NSLocalizedString("Continue", comment: "V2 continue button")
+        NSLocalizedString("Continue", comment: "V2 continue button")
     }
 
     private var continueEnabled: Bool {

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/Views/PasskeyFormV2View.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/Views/PasskeyFormV2View.swift
@@ -34,6 +34,11 @@ struct PasskeyFormV2View: View {
     /// Inline error from the file picker — fires when an upload exceeds the
     /// 6 MB cap. Cleared on a fresh successful upload.
     @Binding var fileSizeError: String?
+    /// Inline error rendered under the websites card when one of the entries
+    /// fails URL validation on save (mirrors V1 PasskeyFormView "Wrong format
+    /// of website"). Set by V2HostView.handleFormSave; cleared on the next
+    /// save attempt and on form reopen.
+    @Binding var websiteError: String?
 
     var saveError: String? = nil
     /// Disables Save/Discard while the passkey is being generated and the
@@ -139,6 +144,13 @@ struct PasskeyFormV2View: View {
                                 }
                             )
 
+                            if let websiteError = websiteError {
+                                Text(websiteError)
+                                    .font(PPTypography.caption)
+                                    .foregroundColor(PPColors.surfaceError)
+                                    .padding(.top, PPSpacing.s4)
+                            }
+
                             Spacer().frame(height: PPSpacing.s16)
 
                             // Folder picker — single folder per record (the
@@ -172,14 +184,14 @@ struct PasskeyFormV2View: View {
                                 placeholder: NSLocalizedString("Optional", comment: "V2 comment placeholder")
                             )
 
-                            // Spacer().frame(height: PPSpacing.s16)
-                            //
-                            // PPButton(
-                            //     title: NSLocalizedString("Upload File", comment: "V2 upload file button"),
-                            //     variant: .secondary,
-                            //     isEnabled: !isSaving,
-                            //     action: { showFilePicker = true }
-                            // )
+                            Spacer().frame(height: PPSpacing.s16)
+
+                            PPButton(
+                                title: NSLocalizedString("Upload File", comment: "V2 upload file button"),
+                                variant: .secondary,
+                                isEnabled: !isSaving,
+                                action: { showFilePicker = true }
+                            )
 
                             if !existingAttachments.isEmpty || !attachments.isEmpty {
                                 Spacer().frame(height: PPSpacing.s16)

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/Views/PasskeyFormV2View.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/V2/Views/PasskeyFormV2View.swift
@@ -34,10 +34,7 @@ struct PasskeyFormV2View: View {
     /// Inline error from the file picker — fires when an upload exceeds the
     /// 6 MB cap. Cleared on a fresh successful upload.
     @Binding var fileSizeError: String?
-    /// Inline error rendered under the websites card when one of the entries
-    /// fails URL validation on save (mirrors V1 PasskeyFormView "Wrong format
-    /// of website"). Set by V2HostView.handleFormSave; cleared on the next
-    /// save attempt and on form reopen.
+    /// Inline error under the websites card on URL validation failure.
     @Binding var websiteError: String?
 
     var saveError: String? = nil
@@ -101,20 +98,14 @@ struct PasskeyFormV2View: View {
                                 .padding(.top, PPSpacing.s24)
                                 .padding(.bottom, PPSpacing.s8)
 
-                            // Unified websites card — all input rows + the
-                            // "+ Add Another Website" button share one
-                            // rounded border, with horizontal dividers
-                            // between rows. Empty entries are filtered at
-                            // save time so blank rows don't pollute the
-                            // record's websites array.
+                            // Unified websites card — rows + "+ Add Another Website" share one border.
                             VStack(spacing: 0) {
                                 ForEach(websites.indices, id: \.self) { idx in
+                                    if idx > 0 { websitesDivider }
                                     websiteRow(index: idx)
-
-                                    Rectangle()
-                                        .fill(PPColors.borderPrimary)
-                                        .frame(height: 1)
                                 }
+
+                                websitesDivider
 
                                 Button(action: {
                                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -386,6 +377,13 @@ struct PasskeyFormV2View: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+
+    /// 1pt divider used between rows and above "+ Add Another Website".
+    private var websitesDivider: some View {
+        Rectangle()
+            .fill(Color.white.opacity(0.08))
+            .frame(maxWidth: .infinity, minHeight: 1, maxHeight: 1)
     }
 
     /// Single website row inside the unified websites card. No own border —

--- a/src/containers/Modal/ModifyMasterVaultModalContent/index.jsx
+++ b/src/containers/Modal/ModifyMasterVaultModalContent/index.jsx
@@ -12,6 +12,7 @@ import { validatePasswordChange } from '@tetherto/pearpass-utils-password-check'
 
 import { InputLabel, InputWrapper } from './styles'
 import { useModal } from '../../../context/ModalContext'
+import { useBiometricsAuthentication } from '../../../hooks/useBiometricsAuthentication'
 import { InputPasswordPearPass } from '../../../libComponents'
 import { logger } from '../../../utils/logger'
 import { ModifyVaultsModaContentWrapper } from '../ModifyVaultsModaContentWrapper'
@@ -25,6 +26,7 @@ export const ModifyMasterVaultModalContent = ({ onPasswordChange }) => {
   const { t } = useLingui()
 
   const { updateMasterPassword } = useUserData()
+  const { refreshBiometricEncryption } = useBiometricsAuthentication()
 
   const [isLoading, setIsLoading] = useState(false)
 
@@ -80,6 +82,10 @@ export const ModifyMasterVaultModalContent = ({ onPasswordChange }) => {
         newPassword: newPasswordBuffer,
         currentPassword: currentPasswordBuffer
       })
+
+      // Re-encrypt biometric SecureStore entry with the rotated master
+      // encryption so autofill biometric unlock keeps working.
+      await refreshBiometricEncryption()
 
       setIsLoading(false)
       onPasswordChange?.()

--- a/src/hooks/useBiometricsAuthentication.js
+++ b/src/hooks/useBiometricsAuthentication.js
@@ -99,6 +99,41 @@ export const useBiometricsAuthentication = () => {
     [enableBiometrics, disableBiometrics]
   )
 
+  /**
+   * Re-saves ENCRYPTION_DATA in SecureStore with the current vault's
+   * ciphertext/nonce/hashedPassword. Call this after operations that rotate
+   * the master encryption (e.g. master password change) so autofill's
+   * biometric unlock keeps working without prompting the user to re-enable
+   * biometrics. No-op when biometrics aren't enabled.
+   */
+  const refreshBiometricEncryption = useCallback(async () => {
+    try {
+      const enabled = await SecureStore.getItemAsync(
+        SECURE_STORAGE_KEYS.BIOMETRICS_ENABLED,
+        { accessGroup: IOS_APP_GROUP_ID }
+      )
+      if (enabled !== 'true') {
+        return { success: true, skipped: true }
+      }
+
+      const { ciphertext, nonce, hashedPassword } = await getMasterEncryption()
+
+      await SecureStore.setItemAsync(
+        SECURE_STORAGE_KEYS.ENCRYPTION_DATA,
+        JSON.stringify({ ciphertext, nonce, hashedPassword }),
+        {
+          requireAuthentication: true,
+          accessGroup: IOS_APP_GROUP_ID
+        }
+      )
+
+      return { success: true }
+    } catch (error) {
+      logger.error('Error refreshing biometric encryption:', error)
+      return { success: false, error: error.toString() }
+    }
+  }, [])
+
   useEffect(() => {
     const checkBiometricSupport = async () => {
       const hasHardware = await LocalAuthentication.hasHardwareAsync()
@@ -136,6 +171,7 @@ export const useBiometricsAuthentication = () => {
     isBiometricsEnabled,
     enableBiometrics,
     disableBiometrics,
-    toggleBiometrics
+    toggleBiometrics,
+    refreshBiometricEncryption
   }
 }

--- a/src/jobQueue/useJobQueueProcessor.js
+++ b/src/jobQueue/useJobQueueProcessor.js
@@ -137,7 +137,9 @@ export const useJobQueueProcessor = () => {
     if (isVaultActive) {
       triggerProcessing()
     }
-  }, [isVaultActive])
+    // activeVaultId tracks vault switches so jobs queued for the newly
+    // selected vault drain without an app restart.
+  }, [isVaultActive, activeVaultId])
 
   useEffect(() => {
     const handleAppStateChange = (nextState) => {

--- a/src/screens/Settings/MasterPassword/index.jsx
+++ b/src/screens/Settings/MasterPassword/index.jsx
@@ -26,6 +26,7 @@ import Toast from 'react-native-toast-message'
 import { Layout } from 'src/containers/Layout'
 import { BackScreenHeader } from 'src/containers/ScreenHeader/BackScreenHeader'
 
+import { useBiometricsAuthentication } from '../../../hooks/useBiometricsAuthentication'
 import { logger } from '../../../utils/logger'
 
 const STRENGTH_TO_INDICATOR = {
@@ -52,6 +53,7 @@ export const MasterPassword = () => {
   const { t } = useLingui()
   const navigation = useNavigation()
   const { updateMasterPassword } = useUserData()
+  const { refreshBiometricEncryption } = useBiometricsAuthentication()
 
   const [isLoading, setIsLoading] = useState(false)
 
@@ -113,6 +115,11 @@ export const MasterPassword = () => {
         newPassword: newPasswordBuffer,
         currentPassword: currentPasswordBuffer
       })
+
+      // Re-encrypt the biometric SecureStore entry with the rotated master
+      // encryption — without this, autofill biometric unlock keeps using the
+      // pre-rotation ciphertext and fails to open the vault.
+      await refreshBiometricEncryption()
 
       setValue('currentPassword', '')
       setValue('newPassword', '')


### PR DESCRIPTION
### Changes
<!-- Summarize the changes introduced in this PR -->
[v2][Android/iOS]["Login via Passkey" window] All "Login" items with appropriate Passkey are displayed in the Passkey list even they are placed in different Vaults
[v2][Android/iOS]["Login via Passkey" window] All "Login" items with appropriate website and even without Passkey are displayed in the Passkey list
[v2][Android/iOS][Passkey] The Login item created during the Passkey setup within the second Vault is not displayed until the application is restarted
[v2][Android/iOS]["Create Passkey"/"Login Passkey" window] A non-existent "Login" item is displayed in the empty Vault when adding a Passkey to the pre-created "Login" item of another Vault
[v2][Android/iOS][Passkey/Autofill] Error is displayed when logging in to the "Autofill" screen via biometrics

### Testing Notes
<!-- How did you test it? -->
Android emulator & IOS simulator

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->
