### PR TITLE
Add clearStaleVaultsDir utility to handle stale vaults during password creation

### DIFF
--- a/src/screens/OnboardingV2/hooks/usePasswordCreation.js
+++ b/src/screens/OnboardingV2/hooks/usePasswordCreation.js
@@ -17,6 +17,7 @@ import { Platform } from 'react-native'
 import Toast from 'react-native-toast-message'
 
 import { TOAST_CONFIG } from '../../../constants/toast'
+import { clearStaleVaultsDir } from '../../../utils/clearStaleVaultsDir'
 import { logger } from '../../../utils/logger'
 import {
   getPasswordIndicatorVariant,
@@ -149,6 +150,10 @@ export const usePasswordCreation = () => {
     try {
       submitInFlightRef.current = true
       setIsLoading(true)
+      // If a previous attempt was killed mid-flow, the vaults dir on disk
+      // is blind-encrypted with the old hashed password and would refuse
+      // to open with the new one we're about to derive.
+      await clearStaleVaultsDir()
       await createMasterPassword(passwordBuffer)
 
       // Create the default "Personal" vault right after master password setup

--- a/src/screens/OnboardingV2/hooks/usePasswordCreation.test.js
+++ b/src/screens/OnboardingV2/hooks/usePasswordCreation.test.js
@@ -121,6 +121,10 @@ jest.mock('../../../utils/logger', () => ({
   }
 }))
 
+jest.mock('../../../utils/clearStaleVaultsDir', () => ({
+  clearStaleVaultsDir: jest.fn(() => Promise.resolve())
+}))
+
 jest.mock('../../../utils/passwordPolicy', () => ({
   getPasswordIndicatorVariant: () => 'strong',
   getPasswordValidationMessages: () => ({

--- a/src/utils/clearStaleVaultsDir.js
+++ b/src/utils/clearStaleVaultsDir.js
@@ -1,0 +1,34 @@
+import * as FileSystem from 'expo-file-system'
+
+import { getSharedDirectoryPath } from './AppGroupHelper'
+import { logger } from './logger'
+
+// Recovers from a partial master-password creation: if the app was killed
+// between vault-blind-encryption setup and the encryption-store write, the
+// `pearpass/vaults` dir is left blind-encrypted with the previous hashed
+// password and the next attempt will fail to open it with a new salt.
+// Safe to call only before vaults are opened by the worklet (i.e. before
+// createMasterPassword / login).
+export const clearStaleVaultsDir = async () => {
+  try {
+    const sharedDirectory = await getSharedDirectoryPath()
+    const baseDirectory = sharedDirectory
+      ? `file://${sharedDirectory}`
+      : FileSystem.documentDirectory?.replace(/\/$/, '')
+
+    if (!baseDirectory) {
+      return
+    }
+
+    const vaultsPath = `${baseDirectory}/pearpass/vaults`
+    const info = await FileSystem.getInfoAsync(vaultsPath)
+
+    if (!info.exists) {
+      return
+    }
+
+    await FileSystem.deleteAsync(vaultsPath, { idempotent: true })
+  } catch (error) {
+    logger.warn('Failed to clear stale vaults dir:', error)
+  }
+}

--- a/src/utils/clearStaleVaultsDir.test.js
+++ b/src/utils/clearStaleVaultsDir.test.js
@@ -1,0 +1,125 @@
+import * as FileSystem from 'expo-file-system'
+
+import { getSharedDirectoryPath } from './AppGroupHelper'
+import { clearStaleVaultsDir } from './clearStaleVaultsDir'
+import { logger } from './logger'
+
+jest.mock('expo-file-system', () => ({
+  __esModule: true,
+  documentDirectory: 'file:///documents/',
+  getInfoAsync: jest.fn(),
+  deleteAsync: jest.fn()
+}))
+
+jest.mock('./AppGroupHelper', () => ({
+  getSharedDirectoryPath: jest.fn()
+}))
+
+jest.mock('./logger', () => ({
+  logger: {
+    warn: jest.fn()
+  }
+}))
+
+describe('clearStaleVaultsDir', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    FileSystem.getInfoAsync.mockResolvedValue({ exists: false })
+    FileSystem.deleteAsync.mockResolvedValue()
+    getSharedDirectoryPath.mockResolvedValue(null)
+  })
+
+  it('deletes the vaults dir under the document directory when it exists', async () => {
+    FileSystem.getInfoAsync.mockResolvedValueOnce({ exists: true })
+
+    await clearStaleVaultsDir()
+
+    expect(FileSystem.getInfoAsync).toHaveBeenCalledWith(
+      'file:///documents/pearpass/vaults'
+    )
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith(
+      'file:///documents/pearpass/vaults',
+      { idempotent: true }
+    )
+  })
+
+  it('deletes the vaults dir under the iOS shared directory when available', async () => {
+    getSharedDirectoryPath.mockResolvedValueOnce('/group/com.example')
+    FileSystem.getInfoAsync.mockResolvedValueOnce({ exists: true })
+
+    await clearStaleVaultsDir()
+
+    expect(FileSystem.getInfoAsync).toHaveBeenCalledWith(
+      'file:///group/com.example/pearpass/vaults'
+    )
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith(
+      'file:///group/com.example/pearpass/vaults',
+      { idempotent: true }
+    )
+  })
+
+  it('does nothing when the vaults dir does not exist', async () => {
+    FileSystem.getInfoAsync.mockResolvedValueOnce({ exists: false })
+
+    await clearStaleVaultsDir()
+
+    expect(FileSystem.deleteAsync).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when no base directory can be resolved', async () => {
+    Object.defineProperty(FileSystem, 'documentDirectory', {
+      value: null,
+      configurable: true,
+      writable: true
+    })
+
+    try {
+      await clearStaleVaultsDir()
+
+      expect(FileSystem.getInfoAsync).not.toHaveBeenCalled()
+      expect(FileSystem.deleteAsync).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(FileSystem, 'documentDirectory', {
+        value: 'file:///documents/',
+        configurable: true,
+        writable: true
+      })
+    }
+  })
+
+  it('strips a trailing slash from documentDirectory before joining', async () => {
+    FileSystem.getInfoAsync.mockResolvedValueOnce({ exists: true })
+
+    await clearStaleVaultsDir()
+
+    expect(FileSystem.getInfoAsync).toHaveBeenCalledWith(
+      'file:///documents/pearpass/vaults'
+    )
+  })
+
+  it('swallows errors and logs a warning', async () => {
+    const error = new Error('boom')
+    FileSystem.getInfoAsync.mockRejectedValueOnce(error)
+
+    await expect(clearStaleVaultsDir()).resolves.toBeUndefined()
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to clear stale vaults dir:',
+      error
+    )
+    expect(FileSystem.deleteAsync).not.toHaveBeenCalled()
+  })
+
+  it('swallows errors thrown from deleteAsync', async () => {
+    const error = new Error('delete failed')
+    FileSystem.getInfoAsync.mockResolvedValueOnce({ exists: true })
+    FileSystem.deleteAsync.mockRejectedValueOnce(error)
+
+    await expect(clearStaleVaultsDir()).resolves.toBeUndefined()
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to clear stale vaults dir:',
+      error
+    )
+  })
+})


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213978067838382
  - https://app.asana.com/0/0/1214143655731381