### PR TITLE
Fix QR scan failing on Samsung by polling preview snapshots on Androi…

### DIFF
--- a/src/containers/BottomSheetAddDeviceContent/PairAnotherDeviceContent.jsx
+++ b/src/containers/BottomSheetAddDeviceContent/PairAnotherDeviceContent.jsx
@@ -45,7 +45,7 @@ export const PairAnotherDeviceContent = ({
     hasPermission,
     codeScanner,
     device,
-    frameProcessor,
+    cameraRef,
     pauseScanning,
     requestPermission
   } = useQRScanner({
@@ -105,11 +105,11 @@ export const PairAnotherDeviceContent = ({
               </View>
             ) : device ? (
               <Camera
+                ref={cameraRef}
                 device={device}
                 isActive={!isLoading}
                 style={styles.camera}
                 codeScanner={codeScanner}
-                frameProcessor={frameProcessor}
               >
                 <View style={styles.cameraSpot} />
               </Camera>

--- a/src/containers/BottomSheetAddDeviceContent/PairAnotherDeviceContent.test.jsx
+++ b/src/containers/BottomSheetAddDeviceContent/PairAnotherDeviceContent.test.jsx
@@ -82,16 +82,19 @@ jest.mock('../../hooks/useHapticFeedback', () => ({
   })
 }))
 
-jest.mock('../../hooks/useQRScanner', () => ({
-  useQRScanner: () => ({
-    hasPermission: true,
-    codeScanner: { onCodeScanned: jest.fn(), codeTypes: ['qr'] },
-    device: { id: 'back' },
-    frameProcessor: undefined,
-    pauseScanning: jest.fn(),
-    requestPermission: jest.fn()
-  })
-}))
+jest.mock('../../hooks/useQRScanner', () => {
+  const { useRef } = require('react')
+  return {
+    useQRScanner: () => ({
+      hasPermission: true,
+      codeScanner: { onCodeScanned: jest.fn(), codeTypes: ['qr'] },
+      device: { id: 'back' },
+      cameraRef: useRef(null),
+      pauseScanning: jest.fn(),
+      requestPermission: jest.fn()
+    })
+  }
+})
 
 jest.mock('../../libComponents', () => ({
   ButtonPrimary: ({ children }) => {
@@ -127,9 +130,9 @@ describe('PairAnotherDeviceContent', () => {
           codeTypes: ['qr'],
           onCodeScanned: expect.any(Function)
         }),
-        frameProcessor: undefined,
         isActive: true
       })
     )
+    expect(mockCamera.mock.calls[0][0]).not.toHaveProperty('frameProcessor')
   })
 })

--- a/src/containers/BottomSheetQrScannerContent/index.jsx
+++ b/src/containers/BottomSheetQrScannerContent/index.jsx
@@ -28,7 +28,7 @@ export const BottomSheetQrScannerContent = ({ onScanned }) => {
     hasPermission,
     codeScanner,
     device,
-    frameProcessor,
+    cameraRef,
     pauseScanning,
     pickImageForScan,
     requestPermission
@@ -73,6 +73,7 @@ export const BottomSheetQrScannerContent = ({ onScanned }) => {
             <Title>{t`Join Vault from QR code`}</Title>
             {device ? (
               <Camera
+                ref={cameraRef}
                 device={device}
                 isActive={true}
                 style={{
@@ -83,7 +84,6 @@ export const BottomSheetQrScannerContent = ({ onScanned }) => {
                   margin: 16
                 }}
                 codeScanner={codeScanner}
-                frameProcessor={frameProcessor}
               >
                 <CameraSpot />
               </Camera>

--- a/src/containers/BottomSheetQrScannerContent/index.test.jsx
+++ b/src/containers/BottomSheetQrScannerContent/index.test.jsx
@@ -49,17 +49,20 @@ jest.mock('../../context/AutoLockContext', () => ({
   })
 }))
 
-jest.mock('../../hooks/useQRScanner', () => ({
-  useQRScanner: () => ({
-    hasPermission: true,
-    codeScanner: { onCodeScanned: jest.fn(), codeTypes: ['qr'] },
-    device: { id: 'back' },
-    frameProcessor: undefined,
-    pauseScanning: mockPauseScanning,
-    pickImageForScan: mockPickImageForScan,
-    requestPermission: mockRequestPermission
-  })
-}))
+jest.mock('../../hooks/useQRScanner', () => {
+  const { useRef } = require('react')
+  return {
+    useQRScanner: () => ({
+      hasPermission: true,
+      codeScanner: { onCodeScanned: jest.fn(), codeTypes: ['qr'] },
+      device: { id: 'back' },
+      cameraRef: useRef(null),
+      pauseScanning: mockPauseScanning,
+      pickImageForScan: mockPickImageForScan,
+      requestPermission: mockRequestPermission
+    })
+  }
+})
 
 jest.mock('../../libComponents', () => ({
   ButtonPrimary: ({ children }) => {
@@ -100,9 +103,9 @@ describe('BottomSheetQrScannerContent', () => {
           codeTypes: ['qr'],
           onCodeScanned: expect.any(Function)
         }),
-        frameProcessor: undefined,
         isActive: true
       })
     )
+    expect(mockCamera.mock.calls[0][0]).not.toHaveProperty('frameProcessor')
   })
 })

--- a/src/hooks/useQRScanner.js
+++ b/src/hooks/useQRScanner.js
@@ -4,17 +4,17 @@ import { useLingui } from '@lingui/react/macro'
 import * as FileSystem from 'expo-file-system'
 import * as ImagePicker from 'expo-image-picker'
 import { Alert, Linking, Platform } from 'react-native'
-import { useSharedValue } from 'react-native-reanimated'
 import {
   Camera,
   useCodeScanner,
-  useCameraDevice,
-  useFrameProcessor
+  useCameraDevice
 } from 'react-native-vision-camera'
-import { Worklets } from 'react-native-worklets-core'
-import { zxing, decodeBase64 } from 'vision-camera-zxing'
+import { decodeBase64 } from 'vision-camera-zxing'
 
 import { logger } from '../utils/logger'
+
+const ANDROID_SCAN_INTERVAL_MS = 500
+const ANDROID_SNAPSHOT_QUALITY = 50
 
 export const useQRScanner = ({
   onScanned,
@@ -41,7 +41,7 @@ export const useQRScanner = ({
 
   const cameraRef = useRef(null)
   const lastScanTimeRef = useRef(0)
-  const isScanningShared = useSharedValue(true)
+  const isTickInFlightRef = useRef(false)
 
   const device = useCameraDevice('back')
 
@@ -62,7 +62,6 @@ export const useQRScanner = ({
     return formatMap[type]
   }, [])
 
-  // Check current permission status on mount
   const checkCurrentPermissions = useCallback(() => {
     try {
       const status = Camera.getCameraPermissionStatus()
@@ -181,28 +180,6 @@ export const useQRScanner = ({
     return formatMap[zxingFormat] || zxingFormat.toLowerCase()
   }
 
-  const onCodeScannedJS = Worklets.createRunOnJS((results) => {
-    if (results.length > 0) {
-      const { barcodeText, barcodeFormat } = results[0]
-      handleBarCodeScanned({
-        type: mapFormat(barcodeFormat),
-        data: barcodeText
-      })
-    }
-  })
-
-  const frameProcessor = useFrameProcessor(
-    (frame) => {
-      'worklet'
-      if (!isScanningShared.value) return
-      const results = zxing(frame)
-      if (results && results.length > 0) {
-        onCodeScannedJS(results)
-      }
-    },
-    [onCodeScannedJS, isScanningShared]
-  )
-
   const codeScanner = useCodeScanner({
     codeTypes: supportedTypes
       .map(mapSupportedTypeToCodeScannerType)
@@ -222,18 +199,82 @@ export const useQRScanner = ({
   })
 
   const activeCodeScanner = Platform.OS === 'ios' ? codeScanner : undefined
-  const activeFrameProcessor =
-    Platform.OS === 'android' ? frameProcessor : undefined
 
   const pauseScanning = useCallback(() => {
     setIsScanning(false)
-    isScanningShared.value = false
-  }, [isScanningShared])
+  }, [])
 
   const resumeScanning = useCallback(() => {
     setIsScanning(true)
-    isScanningShared.value = true
-  }, [isScanningShared])
+  }, [])
+
+  // Lets the polling loop call the latest handler without restarting.
+  const handleBarCodeScannedRef = useRef(handleBarCodeScanned)
+  useEffect(() => {
+    handleBarCodeScannedRef.current = handleBarCodeScanned
+  }, [handleBarCodeScanned])
+
+  // Samsung's YUV layout breaks vision-camera-zxing's frame processor
+  // (preview renders but nothing decodes). Poll preview snapshots and reuse
+  // the gallery decode path instead.
+  useEffect(() => {
+    if (Platform.OS !== 'android') return
+    if (!isScanning || !hasPermission || !device) return
+
+    let cancelled = false
+    let timeoutId = null
+
+    const tick = async () => {
+      if (cancelled) return
+      if (isTickInFlightRef.current || !cameraRef.current) {
+        timeoutId = setTimeout(tick, ANDROID_SCAN_INTERVAL_MS)
+        return
+      }
+
+      isTickInFlightRef.current = true
+      let snapshotPath = null
+      try {
+        const snapshot = await cameraRef.current.takeSnapshot({
+          quality: ANDROID_SNAPSHOT_QUALITY
+        })
+        snapshotPath = snapshot?.path
+        if (cancelled || !snapshotPath) return
+
+        const base64 = await FileSystem.readAsStringAsync(snapshotPath, {
+          encoding: FileSystem.EncodingType.Base64
+        })
+        if (cancelled) return
+
+        const results = await decodeBase64(base64)
+        if (cancelled || !results || results.length === 0) return
+
+        const { barcodeText, barcodeFormat } = results[0]
+        handleBarCodeScannedRef.current({
+          type: mapFormat(barcodeFormat),
+          data: barcodeText
+        })
+      } catch (error) {
+        logger.error('QR snapshot scan tick failed:', error)
+      } finally {
+        isTickInFlightRef.current = false
+        if (snapshotPath) {
+          FileSystem.deleteAsync(snapshotPath, { idempotent: true }).catch(
+            () => {}
+          )
+        }
+        if (!cancelled) {
+          timeoutId = setTimeout(tick, ANDROID_SCAN_INTERVAL_MS)
+        }
+      }
+    }
+
+    timeoutId = setTimeout(tick, ANDROID_SCAN_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      if (timeoutId) clearTimeout(timeoutId)
+    }
+  }, [isScanning, hasPermission, device])
 
   const scanBarcodeFromImage = useCallback(
     async (imageUri) => {
@@ -304,7 +345,6 @@ export const useQRScanner = ({
     }
   }, [enableGallery, onError, showPermissionAlert, t, scanBarcodeFromImage])
 
-  // Check permissions on mount
   useEffect(() => {
     checkCurrentPermissions()
   }, [checkCurrentPermissions])
@@ -315,7 +355,6 @@ export const useQRScanner = ({
     cameraRef,
     device,
     codeScanner: activeCodeScanner,
-    frameProcessor: activeFrameProcessor,
     pauseScanning,
     resumeScanning,
     pickImageForScan,

--- a/src/hooks/useQRScanner.test.js
+++ b/src/hooks/useQRScanner.test.js
@@ -1,6 +1,7 @@
 import { i18n } from '@lingui/core'
 import { I18nProvider } from '@lingui/react'
-import { act, renderHook } from '@testing-library/react-native'
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+import * as FileSystem from 'expo-file-system'
 import * as ImagePicker from 'expo-image-picker'
 import { Alert, Platform } from 'react-native'
 import { Camera, useCodeScanner } from 'react-native-vision-camera'
@@ -18,28 +19,16 @@ jest.mock('react-native-vision-camera', () => ({
     requestCameraPermission: jest.fn()
   },
   useCameraDevice: jest.fn(() => ({ id: 'back', position: 'back' })),
-  useCodeScanner: jest.fn((config) => config),
-  useFrameProcessor: jest.fn(() => jest.fn()),
-  VisionCameraProxy: { initFrameProcessorPlugin: jest.fn() }
-}))
-
-jest.mock('react-native-reanimated', () => ({
-  useSharedValue: jest.fn((val) => ({ value: val }))
-}))
-
-jest.mock('react-native-worklets-core', () => ({
-  Worklets: {
-    createRunOnJS: jest.fn((fn) => fn)
-  }
+  useCodeScanner: jest.fn((config) => config)
 }))
 
 jest.mock('vision-camera-zxing', () => ({
-  zxing: jest.fn(),
   decodeBase64: jest.fn()
 }))
 
 jest.mock('expo-file-system', () => ({
   readAsStringAsync: jest.fn(() => Promise.resolve('base64data')),
+  deleteAsync: jest.fn(() => Promise.resolve()),
   EncodingType: { Base64: 'base64' }
 }))
 
@@ -62,13 +51,10 @@ describe('useQRScanner', () => {
     onScanned = jest.fn()
     onError = jest.fn()
     jest.clearAllMocks()
-    jest.useFakeTimers()
     Camera.getCameraPermissionStatus.mockReturnValue('granted')
   })
 
   afterEach(() => {
-    jest.clearAllTimers()
-    jest.useRealTimers()
     Object.defineProperty(Platform, 'OS', {
       value: originalPlatform
     })
@@ -251,7 +237,6 @@ describe('useQRScanner', () => {
         onCodeScanned: expect.any(Function)
       })
     )
-    expect(result.current.frameProcessor).toBeUndefined()
 
     act(() => {
       result.current.codeScanner.onCodeScanned([
@@ -260,5 +245,88 @@ describe('useQRScanner', () => {
     })
 
     expect(onScanned).toHaveBeenCalledWith('ios-native-scan', 'qr')
+  })
+
+  it('should not expose a code scanner on android (uses snapshot polling instead)', () => {
+    Object.defineProperty(Platform, 'OS', {
+      value: 'android'
+    })
+
+    const { result } = renderHook(() => useQRScanner({ onScanned, onError }), {
+      wrapper: ({ children }) => (
+        <I18nProvider i18n={i18n}>{children}</I18nProvider>
+      )
+    })
+
+    expect(result.current.codeScanner).toBeUndefined()
+    expect(result.current.cameraRef).toBeDefined()
+    expect(result.current.cameraRef.current).toBeNull()
+  })
+
+  it('should poll the camera via takeSnapshot on android and decode QR codes', async () => {
+    Object.defineProperty(Platform, 'OS', {
+      value: 'android'
+    })
+
+    const takeSnapshot = jest
+      .fn()
+      .mockResolvedValue({ path: '/tmp/snap-1.jpg' })
+
+    decodeBase64.mockResolvedValue([
+      { barcodeText: 'android-poll-data', barcodeFormat: 'QR_CODE' }
+    ])
+
+    const { result } = renderHook(() => useQRScanner({ onScanned, onError }), {
+      wrapper: ({ children }) => (
+        <I18nProvider i18n={i18n}>{children}</I18nProvider>
+      )
+    })
+
+    // Attach a fake camera so the polling tick has something to call
+    result.current.cameraRef.current = { takeSnapshot }
+
+    await waitFor(() => {
+      expect(onScanned).toHaveBeenCalledWith('android-poll-data', 'qr')
+    })
+
+    expect(takeSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ quality: expect.any(Number) })
+    )
+    expect(decodeBase64).toHaveBeenCalledWith('base64data')
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith(
+      '/tmp/snap-1.jpg',
+      expect.objectContaining({ idempotent: true })
+    )
+  })
+
+  it('should stop polling on android when scanning is paused', async () => {
+    Object.defineProperty(Platform, 'OS', {
+      value: 'android'
+    })
+
+    const takeSnapshot = jest
+      .fn()
+      .mockResolvedValue({ path: '/tmp/snap-2.jpg' })
+    decodeBase64.mockResolvedValue([])
+
+    const { result } = renderHook(() => useQRScanner({ onScanned, onError }), {
+      wrapper: ({ children }) => (
+        <I18nProvider i18n={i18n}>{children}</I18nProvider>
+      )
+    })
+
+    result.current.cameraRef.current = { takeSnapshot }
+
+    await waitFor(() => {
+      expect(takeSnapshot).toHaveBeenCalled()
+    })
+
+    act(() => {
+      result.current.pauseScanning()
+    })
+
+    const callsAfterPause = takeSnapshot.mock.calls.length
+    await new Promise((resolve) => setTimeout(resolve, 700))
+    expect(takeSnapshot.mock.calls.length).toBe(callsAfterPause)
   })
 })

--- a/src/screens/ImportVault/ImportScanStep.tsx
+++ b/src/screens/ImportVault/ImportScanStep.tsx
@@ -95,7 +95,7 @@ export const ImportScanStep = ({
     hasPermission,
     codeScanner,
     device,
-    frameProcessor,
+    cameraRef,
     pauseScanning,
     requestPermission
   } = useQRScanner({
@@ -169,11 +169,11 @@ export const ImportScanStep = ({
           <View style={styles.cameraInner}>
             {device ? (
               <Camera
+                ref={cameraRef}
                 device={device}
                 isActive
                 style={styles.camera}
                 codeScanner={codeScanner}
-                frameProcessor={frameProcessor}
               >
                 <View
                   style={[


### PR DESCRIPTION
### Changes

Fixes QR scanning on Samsung devices (preview renders but nothing decodes). `vision-camera-zxing`'s Android frame processor mishandles Samsung's padded YUV row stride (confirmed by mrousavy/react-native-vision-camera#3434 and #1947). On Android, replace it with a ~500 ms `Camera.takeSnapshot()` loop that feeds preview JPEGs into the same `decodeBase64` path the gallery picker uses. iOS is unchanged.

- `src/hooks/useQRScanner.js` — drop frame processor, worklet, `useSharedValue`, `Worklets`; add Android snapshot polling with re-entrancy guard, cancellation, and temp-file cleanup
- `src/screens/ImportVault/ImportScanStep.tsx`, `src/containers/BottomSheetQrScannerContent/index.jsx`, `src/containers/BottomSheetAddDeviceContent/PairAnotherDeviceContent.jsx` — drop `frameProcessor` prop, attach `ref={cameraRef}` to `<Camera>`
- Tests updated; added coverage for the Android polling loop