### PR TITLE
Apply navigation bar inset so footer action button is not covered by …

### DIFF
--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/AuthenticationActivity.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/AuthenticationActivity.java
@@ -16,6 +16,8 @@ import android.widget.inline.InlinePresentationSpec;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
@@ -244,9 +246,20 @@ public class AuthenticationActivity extends AppCompatActivity implements Navigat
             }
             window.setStatusBarColor(android.graphics.Color.TRANSPARENT);
             window.setNavigationBarColor(android.graphics.Color.TRANSPARENT);
+            applyBottomNavBarInset();
         } catch (Exception e) {
             SecureLog.e(TAG, "Error applying partial-height window", e);
         }
+    }
+
+    private void applyBottomNavBarInset() {
+        android.view.View root = findViewById(R.id.fragment_container);
+        if (root == null) return;
+        ViewCompat.setOnApplyWindowInsetsListener(root, (v, insets) -> {
+            int bottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
+            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), bottom);
+            return insets;
+        });
     }
 
     @Override

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/PasskeyRegistrationActivity.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/PasskeyRegistrationActivity.java
@@ -7,6 +7,8 @@ import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
@@ -306,9 +308,20 @@ public class PasskeyRegistrationActivity extends AppCompatActivity implements Na
             }
             window.setStatusBarColor(android.graphics.Color.TRANSPARENT);
             window.setNavigationBarColor(android.graphics.Color.TRANSPARENT);
+            applyBottomNavBarInset();
         } catch (Exception e) {
             SecureLog.e(TAG, "Error applying partial-height window", e);
         }
+    }
+
+    private void applyBottomNavBarInset() {
+        android.view.View root = findViewById(R.id.fragment_container);
+        if (root == null) return;
+        ViewCompat.setOnApplyWindowInsetsListener(root, (v, insets) -> {
+            int bottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
+            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), bottom);
+            return insets;
+        });
     }
 
     @Override

--- a/plugins/expo-autofill-plugin/android-template/res/layout/fragment_combined_items_v2.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/layout/fragment_combined_items_v2.xml
@@ -225,7 +225,7 @@
             android:layout_marginStart="@dimen/pp_v2_spacing_s16"
             android:layout_marginEnd="@dimen/pp_v2_spacing_s16"
             android:layout_marginTop="@dimen/pp_v2_spacing_s16"
-            android:layout_marginBottom="@dimen/pp_v2_spacing_s32"
+            android:layout_marginBottom="@dimen/pp_v2_spacing_s16"
             android:background="@drawable/pp_v2_btn_primary"
             android:clickable="true"
             android:focusable="true"

--- a/plugins/expo-autofill-plugin/android-template/res/layout/fragment_error_boundary_v2.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/layout/fragment_error_boundary_v2.xml
@@ -20,8 +20,7 @@
         android:orientation="vertical"
         android:paddingStart="@dimen/pp_v2_spacing_s16"
         android:paddingEnd="@dimen/pp_v2_spacing_s16"
-        android:paddingTop="@dimen/pp_v2_spacing_s16"
-        android:paddingBottom="@dimen/pp_v2_spacing_s16">
+        android:paddingTop="@dimen/pp_v2_spacing_s16">
 
         
         <ImageView

--- a/plugins/expo-autofill-plugin/android-template/res/layout/fragment_master_password_v2.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/layout/fragment_master_password_v2.xml
@@ -85,7 +85,7 @@
             android:layout_marginStart="@dimen/pp_v2_spacing_s16"
             android:layout_marginEnd="@dimen/pp_v2_spacing_s16"
             android:layout_marginTop="@dimen/pp_v2_spacing_s16"
-            android:layout_marginBottom="@dimen/pp_v2_spacing_s32">
+            android:layout_marginBottom="@dimen/pp_v2_spacing_s16">
 
             <Button
                 android:id="@+id/masterPwdContinue"

--- a/plugins/expo-autofill-plugin/android-template/res/layout/fragment_missing_configuration_v2.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/layout/fragment_missing_configuration_v2.xml
@@ -19,8 +19,7 @@
         android:orientation="vertical"
         android:paddingStart="@dimen/pp_v2_spacing_s16"
         android:paddingEnd="@dimen/pp_v2_spacing_s16"
-        android:paddingTop="@dimen/pp_v2_spacing_s16"
-        android:paddingBottom="@dimen/pp_v2_spacing_s16">
+        android:paddingTop="@dimen/pp_v2_spacing_s16">
 
         <ImageView
             android:layout_width="75dp"

--- a/plugins/expo-autofill-plugin/android-template/res/layout/fragment_passkey_form_v2.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/layout/fragment_passkey_form_v2.xml
@@ -206,7 +206,7 @@
         android:paddingStart="@dimen/pp_v2_spacing_s16"
         android:paddingEnd="@dimen/pp_v2_spacing_s16"
         android:paddingTop="@dimen/pp_v2_spacing_s16"
-        android:paddingBottom="@dimen/pp_v2_spacing_s32">
+        android:paddingBottom="@dimen/pp_v2_spacing_s16">
 
         <TextView
             android:id="@+id/formSaveError"


### PR DESCRIPTION
### Changes

- Apply navigation bar inset so footer action button is not covered by the system nav bar.

### Screenshots/Recordings

<img width="472" height="929" alt="Screenshot 2026-05-04 at 18 51 54" src="https://github.com/user-attachments/assets/2db48243-3c35-44f8-a92f-baee15bd4a03" />

<img width="472" height="929" alt="Screenshot 2026-05-04 at 18 52 08" src="https://github.com/user-attachments/assets/c214dca5-6982-439d-9dd7-979fa48c0a6f" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214500598434036