### PR TITLE
fix/ 2.1.0 version bottomsheet issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@expo/metro-runtime": "~5.0.4",
-        "@gorhom/bottom-sheet": "5",
+        "@gorhom/bottom-sheet": "5.2.9",
         "@lingui/core": "5.3.3",
         "@lingui/macro": "5.3.3",
         "@lingui/react": "5.3.3",
@@ -4879,9 +4879,9 @@
       }
     },
     "node_modules/@gorhom/bottom-sheet": {
-      "version": "5.2.14",
-      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.14.tgz",
-      "integrity": "sha512-uLQFlDjp9z+jrOFcMSEldPqL5JdaXL3vXOh+juhwoNvXgTsEorJLjHTugXu+YccAG/0KJnShzKCrb71MHBsvJg==",
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.9.tgz",
+      "integrity": "sha512-YwieCsEnTQnN2QW4VBKfCGszzxaw2ID7FydusEgqo7qB817fZ45N88kptcuNwZFnnauCjdyzKdrVBWmLmpl9oQ==",
       "license": "MIT",
       "dependencies": {
         "@gorhom/portal": "1.0.14",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
-    "@gorhom/bottom-sheet": "5",
+    "@gorhom/bottom-sheet": "5.2.9",
     "@lingui/core": "5.3.3",
     "@lingui/macro": "5.3.3",
     "@lingui/react": "5.3.3",


### PR DESCRIPTION
### Changes
<!-- Summarize the changes introduced in this PR -->
Gorhom/bottom-sheet version issue was on 5.2.14. The new stabile version is 5.2.9

### Testing Notes
<!-- How did you test it? -->
Android emulator & IOS simulator

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

https://github.com/user-attachments/assets/ea1be387-e21f-4b6b-89eb-ddd5b8b02086



