### PR TITLE
Fixes for 2fa Authenticator bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7506,7 +7506,7 @@
     "node_modules/@tetherto/pearpass-lib-data-export": {
       "name": "pearpass-lib-data-export",
       "version": "0.0.13",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-data-export.git#f781ae733b4a41969cf5d0e1319f9bbcb7356507",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-data-export.git#ac0dcdfc1db3506c624dce6316aa4c6ab109cbdb",
       "license": "Apache-2.0"
     },
     "node_modules/@tetherto/pearpass-lib-data-import": {

--- a/src/screens/CreateRecord/v2/CreateOrEditAuthenticatorContent.tsx
+++ b/src/screens/CreateRecord/v2/CreateOrEditAuthenticatorContent.tsx
@@ -69,7 +69,7 @@ export const CreateOrEditAuthenticatorContent = ({
     otpSecret: Validator.string().refine(validateOtpInput)
   })
 
-  const { handleSubmit, register, values, setValue, errors } =
+  const { handleSubmit, register, values, setValue, setErrors, errors } =
     useForm<FormValues>({
       initialValues: {
         title: '',
@@ -173,6 +173,16 @@ export const CreateOrEditAuthenticatorContent = ({
   const titleField = register('title')
   const otpSecretField = register('otpSecret')
 
+  // Clear the OTP error as soon as the user touches the field again (typing,
+  // scanning, or clearing). The submit-time validator will re-set it if the
+  // new value is still invalid.
+  const handleOtpSecretChange = (value: string) => {
+    setValue('otpSecret', value)
+    if (errors?.otpSecret) {
+      setErrors((prev) => ({ ...prev, otpSecret: null }))
+    }
+  }
+
   return (
     <Layout
       scrollable
@@ -221,10 +231,10 @@ export const CreateOrEditAuthenticatorContent = ({
           label={t`Authenticator Secret Key`}
           value={otpSecretField.value}
           placeholder={t`Enter your key or URI`}
-          onChangeText={(value) => setValue('otpSecret', value)}
+          onChangeText={handleOtpSecretChange}
           error={errors.otpSecret as string | undefined}
           rightSlot={
-            <OtpSecretScanButton onScanned={(secret) => setValue('otpSecret', secret)} />
+            <OtpSecretScanButton onScanned={handleOtpSecretChange} />
           }
           testID="otp-secret-field"
         />

--- a/src/screens/CreateRecord/v2/CreateOrEditAuthenticatorContent.tsx
+++ b/src/screens/CreateRecord/v2/CreateOrEditAuthenticatorContent.tsx
@@ -173,9 +173,6 @@ export const CreateOrEditAuthenticatorContent = ({
   const titleField = register('title')
   const otpSecretField = register('otpSecret')
 
-  // Clear the OTP error as soon as the user touches the field again (typing,
-  // scanning, or clearing). The submit-time validator will re-set it if the
-  // new value is still invalid.
   const handleOtpSecretChange = (value: string) => {
     setValue('otpSecret', value)
     if (errors?.otpSecret) {

--- a/src/screens/CreateRecord/v2/CreateOrEditLoginContent.tsx
+++ b/src/screens/CreateRecord/v2/CreateOrEditLoginContent.tsx
@@ -391,11 +391,11 @@ export const CreateOrEditLoginContent = ({
                       size="small"
                       aria-label={t`Remove Authenticator Code`}
                       iconBefore={<Close color={theme.colors.colorTextPrimary} />}
-                      onClick={() => setValue('otpSecret', '')}
+                      onClick={() => register('otpSecret').onChange('')}
                       data-testid="otp-secret-clear-button"
                     />
                   ) : null}
-                  <OtpSecretScanButton onScanned={(secret) => setValue('otpSecret', secret)} />
+                  <OtpSecretScanButton onScanned={(secret) => register('otpSecret').onChange(secret)} />
                 </View>
               }
               testID="otp-secret-field"

--- a/src/screens/RecordDetails/v2/LoginRecordDetailsForm.tsx
+++ b/src/screens/RecordDetails/v2/LoginRecordDetailsForm.tsx
@@ -82,7 +82,7 @@ export const LoginRecordDetailsForm = ({
       credential: initialRecord?.data?.credential?.id ?? '',
       passkeyCreatedAt: initialRecord?.data?.passkeyCreatedAt ?? null
     }),
-    [initialRecord, selectedFolder]
+    [initialRecord?.id, initialRecord?.updatedAt, selectedFolder]
   )
 
   const { register, setValues, values, setValue } =

--- a/src/screens/RecordDetails/v2/types.ts
+++ b/src/screens/RecordDetails/v2/types.ts
@@ -18,6 +18,7 @@ export interface BaseRecord<T = unknown> {
   attachments?: Attachment[]
   otpPublic?: OtpPublic
   passkeyCreatedAt?: Date | string | null
+  updatedAt?: number
   data?: T
 }
 


### PR DESCRIPTION
### Changes

[Android/iOS][Authenticator] Error under the "Authenticator secret key" field does not disappear when scanning the "Authenticator secret key" QR-code
[Android/iOS][Authenticator][Item details] The file is not displayed on the "Item Details" screen when the "Authenticator" field is filled out
[Android/iOS][Authenticator][Export Items] The "Authenticator secret key" field's value is not exported .csv format


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214834729029300