### PR TITLE
Add Revoke Access flow to paired devices

### DIFF
--- a/src/containers/BottomSheetRevokeAccessContent/index.jsx
+++ b/src/containers/BottomSheetRevokeAccessContent/index.jsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+
+import { useLingui } from '@lingui/react/macro'
+import {
+  Button,
+  Text,
+  rawTokens,
+  useBottomSheetClose,
+  useTheme
+} from '@tetherto/pearpass-lib-ui-kit'
+import { kickDevice } from '@tetherto/pearpass-lib-vault'
+import { StyleSheet, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import Toast from 'react-native-toast-message'
+
+import { TOAST_CONFIG } from '../../constants/toast'
+import { logger } from '../../utils/logger'
+import { SheetHeader } from '../BottomSheet/SheetHeader'
+
+export const BottomSheetRevokeAccessContent = ({
+  vaultId,
+  targetDeviceId,
+  deviceName
+}) => {
+  const { t } = useLingui()
+  const { theme } = useTheme()
+  const close = useBottomSheetClose()
+  const { bottom } = useSafeAreaInsets()
+  const [isLoading, setIsLoading] = useState(false)
+
+  const onRevoke = async () => {
+    if (isLoading) return
+    setIsLoading(true)
+    let failures = []
+    try {
+      ;({ failures } = await kickDevice({ vaultId, targetDeviceId }))
+    } catch (error) {
+      logger.error(
+        'BottomSheetRevokeAccessContent',
+        'kickDevice failed:',
+        error
+      )
+      Toast.show({
+        type: 'baseToast',
+        text1: t`Couldn't revoke access. Please try again.`,
+        position: 'bottom',
+        bottomOffset: TOAST_CONFIG.BOTTOM_OFFSET
+      })
+      setIsLoading(false)
+      return
+    }
+
+    close()
+    Toast.show({
+      type: 'baseToast',
+      text1: failures?.length
+        ? t`Couldn't reach the device. It will lose access next time it comes online.`
+        : t`"${deviceName}" no longer has access to this vault`,
+      position: 'bottom',
+      bottomOffset: TOAST_CONFIG.BOTTOM_OFFSET
+    })
+  }
+
+  return (
+    <View style={[styles.container, { paddingBottom: bottom }]}>
+      <SheetHeader
+        title={t`Revoke access for ${deviceName}?`}
+        onClose={close}
+      />
+
+      <View style={styles.content}>
+        <View style={styles.body}>
+          <View>
+            <Text variant="label" color={theme.colors.colorTextSecondary}>
+              {t`This will disconnect the device from future syncing.`}
+            </Text>
+            <Text variant="label" color={theme.colors.colorTextSecondary}>
+              {t`Before you proceed, please note:`}
+            </Text>
+          </View>
+
+          <View style={styles.bulletList}>
+            <View style={styles.bulletRow}>
+              <Text variant="label" style={styles.bulletGlyph}>
+                {'•'}
+              </Text>
+              <Text variant="label" style={styles.bulletText}>
+                {t`For Your Security: We recommend moving your items to a new vault and updating your passwords. This is especially important if the device was lost or stolen, as it ensures your data remains protected even if a local copy exists on the revoked device.`}
+              </Text>
+            </View>
+            <View style={styles.bulletRow}>
+              <Text variant="label" style={styles.bulletGlyph}>
+                {'•'}
+              </Text>
+              <Text variant="label" style={styles.bulletText}>
+                {t`Offline Data: Revoking access prevents future syncing, but it cannot remotely delete data that was already exported.`}
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.actions}>
+          <Button
+            variant="destructive"
+            size="medium"
+            fullWidth
+            isLoading={isLoading}
+            onClick={onRevoke}
+            testID="revoke-access-submit"
+          >
+            {t`Revoke Access`}
+          </Button>
+          <Button
+            variant="secondary"
+            size="medium"
+            fullWidth
+            disabled={isLoading}
+            onClick={close}
+            testID="revoke-access-cancel"
+          >
+            {t`Cancel`}
+          </Button>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%'
+  },
+  content: {
+    paddingHorizontal: rawTokens.spacing16,
+    paddingTop: rawTokens.spacing8,
+    gap: rawTokens.spacing16
+  },
+  body: {
+    gap: rawTokens.spacing12
+  },
+  bulletList: {
+    gap: rawTokens.spacing12
+  },
+  bulletRow: {
+    flexDirection: 'row',
+    gap: rawTokens.spacing8
+  },
+  bulletGlyph: {
+    width: rawTokens.spacing12
+  },
+  bulletText: {
+    flex: 1
+  },
+  actions: {
+    gap: rawTokens.spacing16
+  }
+})

--- a/src/screens/Settings/PairedDevicesScreen/index.jsx
+++ b/src/screens/Settings/PairedDevicesScreen/index.jsx
@@ -1,17 +1,54 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { useLingui } from '@lingui/react/macro'
 import { useNavigation } from '@react-navigation/native'
-import { rawTokens, Text, useTheme } from '@tetherto/pearpass-lib-ui-kit'
-import { useVault } from '@tetherto/pearpass-lib-vault'
-import { StyleSheet, View } from 'react-native'
+import {
+  Button,
+  ContextMenu,
+  NativeBottomSheet,
+  NavbarListItem,
+  rawTokens,
+  Text,
+  useBottomSheetClose,
+  useTheme
+} from '@tetherto/pearpass-lib-ui-kit'
+import { DoNotDisturb, MoreVert } from '@tetherto/pearpass-lib-ui-kit/icons'
+import { getMyDeviceId, useVault } from '@tetherto/pearpass-lib-vault'
+import { Platform, StyleSheet, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
+import { BottomSheetRevokeAccessContent } from '../../../containers/BottomSheetRevokeAccessContent'
 import { Layout } from '../../../containers/Layout'
 import { BackScreenHeader } from '../../../containers/ScreenHeader/BackScreenHeader'
 import {
   formatDeviceDate,
   getDeviceIcon
 } from '../../../utils/devicePresentation'
+import { logger } from '../../../utils/logger'
+
+const RevokeActionMenu = ({ onRevoke }) => {
+  const { t } = useLingui()
+  const { theme } = useTheme()
+  const close = useBottomSheetClose()
+  const { bottom } = useSafeAreaInsets()
+
+  return (
+    <View style={{ paddingBottom: bottom }}>
+      <NavbarListItem
+        platform="mobile"
+        icon={
+          <DoNotDisturb color={theme.colors.colorSurfaceDestructiveElevated} />
+        }
+        label={t`Revoke Access`}
+        variant="destructive"
+        onClick={() => {
+          close()
+          onRevoke()
+        }}
+      />
+    </View>
+  )
+}
 
 export const PairedDevicesScreen = () => {
   const { t } = useLingui()
@@ -23,6 +60,35 @@ export const PairedDevicesScreen = () => {
     refetchVault()
   }, [])
 
+  const currentDeviceName = useMemo(
+    () => `${Platform.OS} ${Platform.Version}`,
+    []
+  )
+
+  const [myDeviceId, setMyDeviceId] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    getMyDeviceId()
+      .then((id) => {
+        if (!cancelled) setMyDeviceId(id ?? null)
+      })
+      .catch((error) => {
+        logger.error('PairedDevicesScreen', 'getMyDeviceId failed:', error)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [data?.devices])
+
+  const isCurrentDevice = (device) => {
+    if (!device) return false
+    if (myDeviceId && device.id === myDeviceId) return true
+    return device.name === currentDeviceName
+  }
+
+  const [revokeTarget, setRevokeTarget] = useState(null)
+
   const getDeviceDisplayName = (deviceName) => {
     if (!deviceName) return t`Unknown Device`
     const lowerName = deviceName.toLowerCase()
@@ -32,6 +98,7 @@ export const PairedDevicesScreen = () => {
   }
 
   const devices = data?.devices ?? []
+  const vaultId = data?.id
 
   return (
     <Layout
@@ -54,6 +121,8 @@ export const PairedDevicesScreen = () => {
           {devices.map((device, index) => {
             const isLast = index === devices.length - 1
             const DeviceIcon = getDeviceIcon(device?.name)
+            const displayName = getDeviceDisplayName(device?.name)
+            const isSelf = isCurrentDevice(device)
 
             return (
               <View
@@ -84,7 +153,7 @@ export const PairedDevicesScreen = () => {
 
                 <View style={styles.deviceInfo}>
                   <Text variant="bodyEmphasized" numberOfLines={1}>
-                    {getDeviceDisplayName(device?.name)}
+                    {displayName}
                   </Text>
                   <View style={styles.deviceDates}>
                     {device.createdAt && (
@@ -98,11 +167,50 @@ export const PairedDevicesScreen = () => {
                     )}
                   </View>
                 </View>
+
+                {!isSelf && device.id && (
+                  <ContextMenu
+                    trigger={
+                      <Button
+                        variant="tertiary"
+                        size="small"
+                        aria-label={t`Device actions`}
+                        iconBefore={
+                          <MoreVert color={theme.colors.colorTextPrimary} />
+                        }
+                      />
+                    }
+                  >
+                    <RevokeActionMenu
+                      onRevoke={() =>
+                        setRevokeTarget({
+                          deviceId: device.id,
+                          deviceName: displayName
+                        })
+                      }
+                    />
+                  </ContextMenu>
+                )}
               </View>
             )
           })}
         </View>
       )}
+
+      <NativeBottomSheet
+        open={revokeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setRevokeTarget(null)
+        }}
+      >
+        {revokeTarget && vaultId && (
+          <BottomSheetRevokeAccessContent
+            vaultId={vaultId}
+            targetDeviceId={revokeTarget.deviceId}
+            deviceName={revokeTarget.deviceName}
+          />
+        )}
+      </NativeBottomSheet>
     </Layout>
   )
 }


### PR DESCRIPTION
Changes:
- New `BottomSheetRevokeAccessContent` confirm sheet that calls `kickDevice` and surfaces a single success-or-partial-failure toast.
- `PairedDevicesScreen`: per-row context menu with a destructive "Revoke Access" action; hidden on the self row.
- Sheet typography: 14px (`label` variant); 16px gap between buttons and between buttons and the text container; 8px padding between the header and the text container.