### PR TITLE
Bump pearpass-lib-vault to pull in Revoke Access support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8740,7 +8740,7 @@
     "node_modules/@tetherto/pearpass-lib-vault": {
       "name": "pearpass-lib-vault",
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault.git#1c8e4a2a2d135c98cf59aadea5a73f0972e235e7",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault.git#7e58479a45f8f802d2e8cb8145d526e74495c3af",
       "license": "Apache-2.0",
       "dependencies": {
         "@reduxjs/toolkit": "2.5.0",
@@ -8753,7 +8753,7 @@
     },
     "node_modules/@tetherto/pearpass-lib-vault-core": {
       "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault-core.git#bb40363e52deb9ac7c1def15a3122e36c891de67",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault-core.git#a2f686326cd41b14782be78168a04dfaa31beaa6",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",


### PR DESCRIPTION
Changes:
- Bump `pearpass-lib-vault` (`d33f3c6` -> `7e58479`) and `pearpass-lib-vault-core` (`89ae20d` -> `a2f6863`) so this app picks up the `KICK_DEVICE` action handler and the broadcastAction signing/verification needed for receiver-side wipes.
- Without this, kicks initiated from another device (desktop/extension) raise `inbox: dropped malformed or unsigned envelope` here and the local vault never wipes.