### PR TITLE
Fix/passkey android autofill

### DIFF
--- a/plugins/expo-autofill-plugin/android-template/java/autofill/data/CredentialItem.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/data/CredentialItem.java
@@ -5,13 +5,23 @@ import java.util.ArrayList;
 import java.util.Map;
 
 public class CredentialItem {
+    public static final String TYPE_LOGIN = "login";
+    public static final String TYPE_CREDIT_CARD = "creditCard";
+
     private String id;
+    private String recordType = TYPE_LOGIN;
     private String title;
     private String username;
     private String password;
     private String url;
     private String notes;
     private List<String> websites;
+
+    // Credit card fields
+    private String cardNumber;
+    private String cardExpireDate;
+    private String cardSecurityCode;
+    private String cardholderName;
 
     // Passkey fields
     private boolean hasPasskey;
@@ -114,6 +124,30 @@ public class CredentialItem {
     public void setWebsites(List<String> websites) {
         this.websites = websites != null ? websites : new ArrayList<>();
     }
+
+    public String getRecordType() {
+        return recordType;
+    }
+
+    public void setRecordType(String recordType) {
+        this.recordType = recordType != null ? recordType : TYPE_LOGIN;
+    }
+
+    public boolean isCreditCard() {
+        return TYPE_CREDIT_CARD.equals(recordType);
+    }
+
+    public String getCardNumber() { return cardNumber; }
+    public void setCardNumber(String cardNumber) { this.cardNumber = cardNumber; }
+
+    public String getCardExpireDate() { return cardExpireDate; }
+    public void setCardExpireDate(String cardExpireDate) { this.cardExpireDate = cardExpireDate; }
+
+    public String getCardSecurityCode() { return cardSecurityCode; }
+    public void setCardSecurityCode(String cardSecurityCode) { this.cardSecurityCode = cardSecurityCode; }
+
+    public String getCardholderName() { return cardholderName; }
+    public void setCardholderName(String cardholderName) { this.cardholderName = cardholderName; }
 
     // Passkey getters and setters
 

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/jobs/PasskeyJobCreator.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/jobs/PasskeyJobCreator.java
@@ -158,7 +158,6 @@ public class PasskeyJobCreator {
         long createdAt = System.currentTimeMillis();
 
         // 2. Build the payload
-        String note = formData.getNote();
         UpdatePasskeyPayload payload = new UpdatePasskeyPayload(
                 existingRecordId,
                 rpId, rpName,
@@ -173,7 +172,11 @@ public class PasskeyJobCreator {
                 createdAt,
                 credential.getResponse().getTransports(),
                 vaultId,
-                (note != null && !note.isEmpty()) ? note : null,
+                formData.getTitle(),
+                formData.getUsername(),
+                formData.getWebsites(),
+                formData.getFolder(),
+                formData.getNote() != null ? formData.getNote() : "",
                 attachments,
                 formData.getKeepAttachmentIds()
         );

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/jobs/UpdatePasskeyPayload.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/jobs/UpdatePasskeyPayload.java
@@ -44,6 +44,10 @@ public class UpdatePasskeyPayload {
     private final String vaultId;
 
     // User-edited fields
+    private final String title;
+    private final String username;
+    private final List<String> websites;
+    private final String folder;
     private final String note;
     private final List<JobAttachment> attachments;
     private final List<String> keepAttachmentIds;
@@ -56,6 +60,10 @@ public class UpdatePasskeyPayload {
                                 String authenticatorData,
                                 int algorithm, long createdAt, List<String> transports,
                                 String vaultId,
+                                String title,
+                                String username,
+                                List<String> websites,
+                                String folder,
                                 String note,
                                 List<JobAttachment> attachments,
                                 List<String> keepAttachmentIds) {
@@ -75,6 +83,10 @@ public class UpdatePasskeyPayload {
         this.createdAt = createdAt;
         this.transports = transports != null ? transports : new ArrayList<>();
         this.vaultId = vaultId;
+        this.title = title;
+        this.username = username;
+        this.websites = websites != null ? websites : new ArrayList<>();
+        this.folder = folder;
         this.note = note;
         this.attachments = attachments != null ? attachments : new ArrayList<>();
         this.keepAttachmentIds = keepAttachmentIds != null ? keepAttachmentIds : new ArrayList<>();
@@ -98,6 +110,10 @@ public class UpdatePasskeyPayload {
     public long getCreatedAt() { return createdAt; }
     public List<String> getTransports() { return transports; }
     public String getVaultId() { return vaultId; }
+    public String getTitle() { return title; }
+    public String getUsername() { return username; }
+    public List<String> getWebsites() { return websites; }
+    public String getFolder() { return folder; }
     public String getNote() { return note; }
     public List<JobAttachment> getAttachments() { return attachments; }
     public List<String> getKeepAttachmentIds() { return keepAttachmentIds; }
@@ -139,19 +155,27 @@ public class UpdatePasskeyPayload {
 
         json.put("vaultId", vaultId);
 
-        if (note != null) {
-            json.put("note", note);
-        }
+        json.put("title", title != null ? title : JSONObject.NULL);
+        json.put("username", username != null ? username : JSONObject.NULL);
+        json.put("folder", folder != null ? folder : JSONObject.NULL);
 
-        JSONArray attachmentsArray = new JSONArray();
+        JSONArray websitesArray = new JSONArray();
+        for (String website : websites) {
+            websitesArray.put(website);
+        }
+        json.put("websites", websitesArray);
+
+        json.put("note", note != null ? note : JSONObject.NULL);
+
+        JSONArray attachmentsJsonArray = new JSONArray();
         for (JobAttachment attachment : attachments) {
             JSONObject attachmentJson = new JSONObject();
             attachmentJson.put("id", attachment.getId());
             attachmentJson.put("name", attachment.getName());
             attachmentJson.put("relativePath", attachment.getRelativePath());
-            attachmentsArray.put(attachmentJson);
+            attachmentsJsonArray.put(attachmentJson);
         }
-        json.put("attachments", attachmentsArray);
+        json.put("attachments", attachmentsJsonArray);
 
         JSONArray keepIdsArray = new JSONArray();
         for (String id : keepAttachmentIds) {
@@ -198,6 +222,15 @@ public class UpdatePasskeyPayload {
             }
         }
 
+        // Websites
+        List<String> websites = new ArrayList<>();
+        JSONArray websitesArray = json.optJSONArray("websites");
+        if (websitesArray != null) {
+            for (int i = 0; i < websitesArray.length(); i++) {
+                websites.add(websitesArray.getString(i));
+            }
+        }
+
         return new UpdatePasskeyPayload(
                 json.getString("existingRecordId"),
                 json.getString("rpId"),
@@ -215,7 +248,11 @@ public class UpdatePasskeyPayload {
                 json.getLong("createdAt"),
                 transports,
                 json.getString("vaultId"),
-                json.optString("note", null),
+                json.isNull("title") ? null : json.optString("title", null),
+                json.isNull("username") ? null : json.optString("username", null),
+                websites,
+                json.isNull("folder") ? null : json.optString("folder", null),
+                json.isNull("note") ? null : json.optString("note", null),
                 attachments,
                 keepAttachmentIds
         );

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/service/PearPassAutofillService.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/service/PearPassAutofillService.java
@@ -52,9 +52,10 @@ public class PearPassAutofillService extends AutofillService {
 
         boolean hasSpecificFields = parsedFields != null
                 && (parsedFields.hasUsernameField() || parsedFields.hasPasswordField());
+        boolean hasCardFields = parsedFields != null && parsedFields.hasCardField();
         boolean hasFallbackFields = parsedFields != null && parsedFields.hasAnyFallbackField();
 
-        if (!hasSpecificFields && !hasFallbackFields) {
+        if (!hasSpecificFields && !hasCardFields && !hasFallbackFields) {
             callback.onSuccess(null);
             return;
         }
@@ -77,6 +78,12 @@ public class PearPassAutofillService extends AutofillService {
         Intent authIntent = new Intent(this, AuthenticationActivity.class);
         authIntent.putExtra("username_id", parsedFields.getUsernameId());
         authIntent.putExtra("password_id", parsedFields.getPasswordId());
+        authIntent.putExtra("card_number_id", parsedFields.getCardNumberId());
+        authIntent.putExtra("card_expiry_date_id", parsedFields.getCardExpiryDateId());
+        authIntent.putExtra("card_expiry_month_id", parsedFields.getCardExpiryMonthId());
+        authIntent.putExtra("card_expiry_year_id", parsedFields.getCardExpiryYearId());
+        authIntent.putExtra("card_security_code_id", parsedFields.getCardSecurityCodeId());
+        authIntent.putExtra("cardholder_name_id", parsedFields.getCardholderNameId());
 
         // Pass domain/package information for credential filtering
         String webDomain = parsedFields.getWebDomain();
@@ -129,105 +136,51 @@ public class PearPassAutofillService extends AutofillService {
         }
 
         FillResponse.Builder responseBuilder = new FillResponse.Builder();
-
-        // Create a single dataset with BOTH fields so they fill together
         Dataset.Builder datasetBuilder = new Dataset.Builder();
 
-        if (parsedFields.hasUsernameField() && parsedFields.hasPasswordField()) {
-            // Both fields present - add both to the same dataset
-            if (inlinePresentation != null) {
-                datasetBuilder.setValue(
-                    parsedFields.getUsernameId(),
-                    AutofillValue.forText(AutofillConstants.PLACEHOLDER_PASSWORD),
-                    presentation,
-                    inlinePresentation
-                );
-                datasetBuilder.setValue(
-                    parsedFields.getPasswordId(),
-                    AutofillValue.forText(AutofillConstants.PLACEHOLDER_PASSWORD),
-                    presentation,
-                    inlinePresentation
-                );
-            } else {
-                datasetBuilder.setValue(
-                    parsedFields.getUsernameId(),
-                    AutofillValue.forText(AutofillConstants.PLACEHOLDER_PASSWORD),
-                    presentation
-                );
-                datasetBuilder.setValue(
-                    parsedFields.getPasswordId(),
-                    AutofillValue.forText(AutofillConstants.PLACEHOLDER_PASSWORD),
-                    presentation
-                );
-            }
-
-            datasetBuilder.setAuthentication(sender);
-            responseBuilder.addDataset(datasetBuilder.build());
-        } else if (parsedFields.hasUsernameField()) {
-            // Only username field
-            if (inlinePresentation != null) {
-                datasetBuilder.setValue(
-                    parsedFields.getUsernameId(),
-                    AutofillValue.forText(AutofillConstants.PLACEHOLDER_PASSWORD),
-                    presentation,
-                    inlinePresentation
-                );
-            } else {
-                datasetBuilder.setValue(
-                    parsedFields.getUsernameId(),
-                    AutofillValue.forText(AutofillConstants.PLACEHOLDER_PASSWORD),
-                    presentation
-                );
-            }
-
-            datasetBuilder.setAuthentication(sender);
-            responseBuilder.addDataset(datasetBuilder.build());
-        } else if (parsedFields.hasPasswordField()) {
-            // Only password field
-            if (inlinePresentation != null) {
-                datasetBuilder.setValue(
-                    parsedFields.getPasswordId(),
-                    AutofillValue.forText(AutofillConstants.PLACEHOLDER_PASSWORD),
-                    presentation,
-                    inlinePresentation
-                );
-            } else {
-                datasetBuilder.setValue(
-                    parsedFields.getPasswordId(),
-                    AutofillValue.forText(AutofillConstants.PLACEHOLDER_PASSWORD),
-                    presentation
-                );
-            }
-
-            datasetBuilder.setAuthentication(sender);
-            responseBuilder.addDataset(datasetBuilder.build());
+        java.util.List<AutofillId> targetIds = new java.util.ArrayList<>();
+        if (parsedFields.hasUsernameField() || parsedFields.hasPasswordField() || hasCardFields) {
+            addIfNotNull(targetIds, parsedFields.getUsernameId());
+            addIfNotNull(targetIds, parsedFields.getPasswordId());
+            addIfNotNull(targetIds, parsedFields.getCardNumberId());
+            addIfNotNull(targetIds, parsedFields.getCardExpiryDateId());
+            addIfNotNull(targetIds, parsedFields.getCardExpiryMonthId());
+            addIfNotNull(targetIds, parsedFields.getCardExpiryYearId());
+            addIfNotNull(targetIds, parsedFields.getCardSecurityCodeId());
+            addIfNotNull(targetIds, parsedFields.getCardholderNameId());
         } else if (hasFallbackFields) {
-            // Fallback: no specific username/password fields detected, but editable text
-            // fields exist. This handles the case where the browser hasn't fully populated
-            // the AssistStructure on the first field tap (common with Chrome compatibility mode).
-            for (AutofillId fallbackId : parsedFields.getFallbackFieldIds()) {
+            // Fallback: no specific fields detected, but editable text fields exist.
+            // Browsers sometimes leave the AssistStructure underpopulated on the first tap.
+            targetIds.addAll(parsedFields.getFallbackFieldIds());
+        }
+
+        if (!targetIds.isEmpty()) {
+            for (AutofillId targetId : targetIds) {
                 if (inlinePresentation != null) {
                     datasetBuilder.setValue(
-                        fallbackId,
+                        targetId,
                         AutofillValue.forText(AutofillConstants.PLACEHOLDER_PASSWORD),
                         presentation,
                         inlinePresentation
                     );
                 } else {
                     datasetBuilder.setValue(
-                        fallbackId,
+                        targetId,
                         AutofillValue.forText(AutofillConstants.PLACEHOLDER_PASSWORD),
                         presentation
                     );
                 }
             }
-
             datasetBuilder.setAuthentication(sender);
             responseBuilder.addDataset(datasetBuilder.build());
         }
 
         FillResponse response = responseBuilder.build();
         callback.onSuccess(response);
+    }
+
+    private static void addIfNotNull(java.util.List<AutofillId> ids, AutofillId id) {
+        if (id != null) ids.add(id);
     }
 
     @Override

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/AuthenticationActivity.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/AuthenticationActivity.java
@@ -43,6 +43,12 @@ public class AuthenticationActivity extends AppCompatActivity implements Navigat
 
     private AutofillId usernameId;
     private AutofillId passwordId;
+    private AutofillId cardNumberId;
+    private AutofillId cardExpiryDateId;
+    private AutofillId cardExpiryMonthId;
+    private AutofillId cardExpiryYearId;
+    private AutofillId cardSecurityCodeId;
+    private AutofillId cardholderNameId;
     private String webDomain;
     private String packageName;
 
@@ -88,6 +94,12 @@ public class AuthenticationActivity extends AppCompatActivity implements Navigat
         Intent intent = getIntent();
         usernameId = intent.getParcelableExtra("username_id");
         passwordId = intent.getParcelableExtra("password_id");
+        cardNumberId = intent.getParcelableExtra("card_number_id");
+        cardExpiryDateId = intent.getParcelableExtra("card_expiry_date_id");
+        cardExpiryMonthId = intent.getParcelableExtra("card_expiry_month_id");
+        cardExpiryYearId = intent.getParcelableExtra("card_expiry_year_id");
+        cardSecurityCodeId = intent.getParcelableExtra("card_security_code_id");
+        cardholderNameId = intent.getParcelableExtra("cardholder_name_id");
         webDomain = intent.getStringExtra("web_domain");
         packageName = intent.getStringExtra("package_name");
 
@@ -168,9 +180,19 @@ public class AuthenticationActivity extends AppCompatActivity implements Navigat
 
     @Override
     public void navigateToVaultSelection() {
+        String recordType = hasCardFields() ? CredentialItem.TYPE_CREDIT_CARD : CredentialItem.TYPE_LOGIN;
         replaceFragment(CombinedItemsFragment.newInstance(
                 CombinedItemsFragment.MODE_ASSERTION,
-                webDomain, packageName, null, null), true);
+                webDomain, packageName, null, null, recordType), true);
+    }
+
+    private boolean hasCardFields() {
+        return cardNumberId != null
+                || cardExpiryDateId != null
+                || cardExpiryMonthId != null
+                || cardExpiryYearId != null
+                || cardSecurityCodeId != null
+                || cardholderNameId != null;
     }
 
     // 85% height sheet anchored to bottom, with a dim backdrop.
@@ -217,20 +239,24 @@ public class AuthenticationActivity extends AppCompatActivity implements Navigat
         RemoteViews presentation = new RemoteViews(getPackageName(), android.R.layout.simple_list_item_1);
         presentation.setTextViewText(android.R.id.text1, credential.getTitle());
 
-        if (usernameId != null) {
-            datasetBuilder.setValue(
-                usernameId,
-                AutofillValue.forText(credential.getUsername()),
-                presentation
-            );
-        }
+        if (credential.isCreditCard()) {
+            applyCardValues(datasetBuilder, credential, presentation);
+        } else {
+            if (usernameId != null) {
+                datasetBuilder.setValue(
+                    usernameId,
+                    AutofillValue.forText(credential.getUsername()),
+                    presentation
+                );
+            }
 
-        if (passwordId != null) {
-            datasetBuilder.setValue(
-                passwordId,
-                AutofillValue.forText(credential.getPassword()),
-                presentation
-            );
+            if (passwordId != null) {
+                datasetBuilder.setValue(
+                    passwordId,
+                    AutofillValue.forText(credential.getPassword()),
+                    presentation
+                );
+            }
         }
 
         Intent replyIntent = new Intent();
@@ -238,6 +264,52 @@ public class AuthenticationActivity extends AppCompatActivity implements Navigat
 
         setResult(Activity.RESULT_OK, replyIntent);
         finish();
+    }
+
+    private void applyCardValues(Dataset.Builder builder, CredentialItem credential, RemoteViews presentation) {
+        if (cardNumberId != null) {
+            String digits = credential.getCardNumber() != null
+                    ? credential.getCardNumber().replaceAll("\\s", "")
+                    : "";
+            builder.setValue(cardNumberId, AutofillValue.forText(digits), presentation);
+        }
+
+        String expire = credential.getCardExpireDate();
+        String[] expiryParts = splitExpiry(expire);
+        if (cardExpiryDateId != null && expire != null) {
+            builder.setValue(cardExpiryDateId, AutofillValue.forText(expire), presentation);
+        }
+        if (cardExpiryMonthId != null && expiryParts[0] != null) {
+            builder.setValue(cardExpiryMonthId, AutofillValue.forText(expiryParts[0]), presentation);
+        }
+        if (cardExpiryYearId != null && expiryParts[1] != null) {
+            builder.setValue(cardExpiryYearId, AutofillValue.forText(expiryParts[1]), presentation);
+        }
+        if (cardSecurityCodeId != null && credential.getCardSecurityCode() != null) {
+            builder.setValue(cardSecurityCodeId,
+                    AutofillValue.forText(credential.getCardSecurityCode()), presentation);
+        }
+        if (cardholderNameId != null && credential.getCardholderName() != null) {
+            builder.setValue(cardholderNameId,
+                    AutofillValue.forText(credential.getCardholderName()), presentation);
+        }
+    }
+
+    private static String[] splitExpiry(String expire) {
+        String[] out = new String[]{null, null};
+        if (expire == null) return out;
+        String trimmed = expire.trim();
+        if (trimmed.isEmpty()) return out;
+        String[] parts = trimmed.split("[/\\-\\s]");
+        if (parts.length >= 2) {
+            out[0] = parts[0];
+            out[1] = parts[1];
+            if (out[1].length() == 2) out[1] = "20" + out[1];
+        } else if (trimmed.length() == 4) {
+            out[0] = trimmed.substring(0, 2);
+            out[1] = "20" + trimmed.substring(2);
+        }
+        return out;
     }
 
     @Override

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CombinedItemsFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CombinedItemsFragment.java
@@ -67,12 +67,14 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
     private static final String ARG_PACKAGE_NAME = "package_name";
     private static final String ARG_RP_ID = "rp_id";
     private static final String ARG_USER_NAME = "user_name";
+    private static final String ARG_RECORD_TYPE = "record_type";
 
     private String mode;
     private String webDomain;
     private String packageName;
     private String rpId;
     private String userName;
+    private String recordTypeFilter = CredentialItem.TYPE_LOGIN;
 
     // Views
     private TextView sheetTitle;
@@ -107,6 +109,15 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
                                                     String packageName,
                                                     String rpId,
                                                     String userName) {
+        return newInstance(mode, webDomain, packageName, rpId, userName, CredentialItem.TYPE_LOGIN);
+    }
+
+    public static CombinedItemsFragment newInstance(String mode,
+                                                    String webDomain,
+                                                    String packageName,
+                                                    String rpId,
+                                                    String userName,
+                                                    String recordType) {
         CombinedItemsFragment f = new CombinedItemsFragment();
         Bundle args = new Bundle();
         args.putString(ARG_MODE, mode);
@@ -114,6 +125,7 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
         args.putString(ARG_PACKAGE_NAME, packageName);
         args.putString(ARG_RP_ID, rpId);
         args.putString(ARG_USER_NAME, userName);
+        args.putString(ARG_RECORD_TYPE, recordType);
         f.setArguments(args);
         return f;
     }
@@ -127,6 +139,7 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
             packageName = getArguments().getString(ARG_PACKAGE_NAME);
             rpId = getArguments().getString(ARG_RP_ID);
             userName = getArguments().getString(ARG_USER_NAME);
+            recordTypeFilter = getArguments().getString(ARG_RECORD_TYPE, CredentialItem.TYPE_LOGIN);
         }
         if (mode == null) mode = MODE_ASSERTION;
     }
@@ -472,6 +485,10 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
     }
 
     private List<CredentialItem> filterInitial(List<CredentialItem> all) {
+        // Credit cards don't carry a website list, so they aren't domain-filterable.
+        if (CredentialItem.TYPE_CREDIT_CARD.equals(recordTypeFilter)) {
+            return new ArrayList<>(all);
+        }
         // In registration mode, prefer records matching rpId/userName; else fall through.
         if (MODE_REGISTRATION.equals(mode) && rpId != null && !rpId.isEmpty()) {
             List<CredentialItem> matches = new ArrayList<>();
@@ -598,6 +615,9 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
 
             emptyState.setText(span);
             emptyState.setMovementMethod(LinkMovementMethod.getInstance());
+        } else if (CredentialItem.TYPE_CREDIT_CARD.equals(recordTypeFilter)) {
+            emptyState.setText("No credit cards in this vault");
+            emptyState.setMovementMethod(null);
         } else {
             emptyState.setText("No matching items in this vault");
             emptyState.setMovementMethod(null);
@@ -628,7 +648,7 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
             if (id == null) continue;
 
             Object recordType = record.get("type");
-            if (!(recordType instanceof String) || !"login".equals(recordType)) {
+            if (!(recordType instanceof String) || !recordTypeFilter.equals(recordType)) {
                 continue;
             }
 
@@ -646,6 +666,18 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
             String name = (String) data.get("title");
             if (name == null) name = (String) data.get("name");
             if (name == null || name.isEmpty()) continue;
+
+            if (CredentialItem.TYPE_CREDIT_CARD.equals(recordTypeFilter)) {
+                CredentialItem cardItem = new CredentialItem(id, name, "", "");
+                cardItem.setRecordType(CredentialItem.TYPE_CREDIT_CARD);
+                cardItem.setCardNumber((String) data.get("number"));
+                cardItem.setCardExpireDate((String) data.get("expireDate"));
+                cardItem.setCardSecurityCode((String) data.get("securityCode"));
+                cardItem.setCardholderName((String) data.get("name"));
+                credentials.add(cardItem);
+                rawRecordsById.put(id, record);
+                continue;
+            }
 
             String uname = (String) data.get("username");
             if (uname == null) uname = (String) data.get("email");

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CombinedItemsFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CombinedItemsFragment.java
@@ -627,6 +627,11 @@ public class CombinedItemsFragment extends BaseAutofillFragment {
             String id = (String) record.get("id");
             if (id == null) continue;
 
+            Object recordType = record.get("type");
+            if (!(recordType instanceof String) || !"login".equals(recordType)) {
+                continue;
+            }
+
             Map<String, Object> data;
             if (record.containsKey("data") && record.get("data") instanceof Map) {
                 data = (Map<String, Object>) record.get("data");

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CredentialAdapter.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/CredentialAdapter.java
@@ -59,14 +59,28 @@ public class CredentialAdapter extends BaseItemAdapter<CredentialItem, Credentia
 
         void bind(CredentialItem c) {
             title.setText(c.getTitle());
-            String uname = c.getUsername();
-            if (uname == null || uname.isEmpty()) {
+            String subtitle;
+            if (c.isCreditCard()) {
+                subtitle = formatCardSubtitle(c);
+            } else {
+                subtitle = c.getUsername();
+            }
+            if (subtitle == null || subtitle.isEmpty()) {
                 username.setVisibility(View.GONE);
             } else {
                 username.setVisibility(View.VISIBLE);
-                username.setText(uname);
+                username.setText(subtitle);
             }
             initials.setText(computeInitials(c.getTitle()));
+        }
+
+        private String formatCardSubtitle(CredentialItem c) {
+            String number = c.getCardNumber();
+            if (number == null) return "";
+            String digits = number.replaceAll("\\D", "");
+            if (digits.isEmpty()) return "";
+            String last4 = digits.length() >= 4 ? digits.substring(digits.length() - 4) : digits;
+            return "•••• " + last4;
         }
 
         private String computeInitials(String t) {

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/ErrorBoundaryFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/ErrorBoundaryFragment.java
@@ -69,10 +69,10 @@ public class ErrorBoundaryFragment extends BaseAutofillFragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        TextView errorTitle = view.findViewById(R.id.errorTitle);
-        TextView errorSubtitle = view.findViewById(R.id.errorSubtitle);
-        TextView errorMessage = view.findViewById(R.id.errorMessage);
-        Button goBackButton = view.findViewById(R.id.errorGoBackButton);
+        TextView errorTitle = view.findViewById(R.id.errorV2Title);
+        TextView errorSubtitle = view.findViewById(R.id.errorV2Subtitle);
+        TextView errorMessage = view.findViewById(R.id.errorV2Message);
+        Button goBackButton = view.findViewById(R.id.errorV2GoBackButton);
 
         View sheetHeader = view.findViewById(R.id.errorSheetHeader);
         if (sheetHeader != null) {

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/MasterPasswordFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/MasterPasswordFragment.java
@@ -19,18 +19,22 @@ import androidx.fragment.app.FragmentActivity;
 import com.pears.pass.R;
 import com.pears.pass.autofill.data.PearPassVaultClient;
 import com.pears.pass.autofill.utils.BiometricAuthHelper;
+import com.pears.pass.autofill.utils.RateLimitManager;
 import com.pears.pass.autofill.utils.SecureLog;
 
 import java.util.concurrent.CompletableFuture;
 
 public class MasterPasswordFragment extends BaseAutofillFragment {
     private BiometricAuthHelper biometricHelper;
+    private RateLimitManager rateLimit;
     private EditText passwordInput;
     private Button unlockButton;
     private TextView biometricButton;
+    private TextView errorText;
     private ImageView togglePasswordVisibility;
     private boolean isAuthenticatingBiometric = false;
     private boolean isPasswordVisible = false;
+    private android.os.CountDownTimer lockoutTimer;
     // Spinner overlay shown over Continue while auth is in flight.
     private android.widget.ProgressBar continueProgress;
 
@@ -38,6 +42,7 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
         biometricHelper = BiometricAuthHelper.getInstance(context);
+        rateLimit = new RateLimitManager(context);
     }
 
     @Override
@@ -68,6 +73,7 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
         unlockButton = view.findViewById(R.id.masterPwdContinue);
         togglePasswordVisibility = view.findViewById(R.id.ppPasswordToggle);
         biometricButton = view.findViewById(R.id.masterPwdBiometricButton);
+        errorText = view.findViewById(R.id.masterPwdError);
         continueProgress = view.findViewById(R.id.masterPwdContinueProgress);
 
         TextView passwordLabel = view.findViewById(R.id.ppPasswordLabel);
@@ -97,10 +103,91 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
             authenticateWithMasterPassword(password);
         });
 
+        passwordInput.addTextChangedListener(new android.text.TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override public void afterTextChanged(android.text.Editable s) {}
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                if (errorText != null && errorText.getVisibility() == View.VISIBLE
+                        && unlockButton.isEnabled()) {
+                    errorText.setVisibility(View.GONE);
+                }
+            }
+        });
+
         setupPasswordVisibilityToggle();
         setupBiometricButton();
+        refreshRateLimitStatus();
 
         return view;
+    }
+
+    @Override
+    public void onDestroyView() {
+        if (lockoutTimer != null) {
+            lockoutTimer.cancel();
+            lockoutTimer = null;
+        }
+        super.onDestroyView();
+    }
+
+    private void refreshRateLimitStatus() {
+        if (rateLimit == null) return;
+        applyRateLimitStatus(rateLimit.getStatus());
+    }
+
+    private void applyRateLimitStatus(RateLimitManager.Status status) {
+        if (errorText == null || unlockButton == null || passwordInput == null) return;
+
+        if (status.isLocked && status.lockoutRemainingMs > 0) {
+            startLockoutCountdown(status.lockoutRemainingMs);
+            return;
+        }
+
+        if (lockoutTimer != null) {
+            lockoutTimer.cancel();
+            lockoutTimer = null;
+        }
+        unlockButton.setEnabled(true);
+        passwordInput.setEnabled(true);
+    }
+
+    private void startLockoutCountdown(long remainingMs) {
+        if (errorText == null || unlockButton == null || passwordInput == null) return;
+
+        unlockButton.setEnabled(false);
+        passwordInput.setEnabled(false);
+        passwordInput.setText("");
+        errorText.setVisibility(View.VISIBLE);
+        errorText.setText(formatLockoutMessage(remainingMs));
+
+        if (lockoutTimer != null) lockoutTimer.cancel();
+        lockoutTimer = new android.os.CountDownTimer(remainingMs, 1000) {
+            @Override
+            public void onTick(long millisUntilFinished) {
+                errorText.setText(formatLockoutMessage(millisUntilFinished));
+            }
+            @Override
+            public void onFinish() {
+                lockoutTimer = null;
+                refreshRateLimitStatus();
+            }
+        }.start();
+    }
+
+    private String formatLockoutMessage(long remainingMs) {
+        long totalSeconds = Math.max(1, (remainingMs + 999) / 1000);
+        long minutes = totalSeconds / 60;
+        long seconds = totalSeconds % 60;
+        String when;
+        if (minutes > 0 && seconds > 0) {
+            when = minutes + "m " + seconds + "s";
+        } else if (minutes > 0) {
+            when = minutes + "m";
+        } else {
+            when = seconds + "s";
+        }
+        return "Too many attempts. Try again in " + when + ".";
     }
 
     /**
@@ -128,6 +215,8 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
                     throw new Exception("Invalid master password - vault remains locked");
                 }
 
+                if (rateLimit != null) rateLimit.reset();
+
                 try {
                     PearPassVaultClient.MasterPasswordEncryption masterEnc =
                         vaultClient.getMasterPasswordEncryption(vaultStatus).get();
@@ -151,12 +240,26 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
             } catch (Exception e) {
                 SecureLog.e("MasterPasswordFragment", "Authentication failed: " + e.getMessage());
 
+                if (rateLimit != null) rateLimit.recordFailure();
+                final RateLimitManager.Status status = rateLimit != null ? rateLimit.getStatus() : null;
+
                 getActivity().runOnUiThread(() -> {
-                    Toast.makeText(getContext(), "Invalid master password", Toast.LENGTH_SHORT).show();
                     unlockButton.setEnabled(true);
                     unlockButton.setText("Continue");
                     if (continueProgress != null) continueProgress.setVisibility(View.GONE);
                     passwordInput.setText("");
+
+                    if (status != null && status.isLocked && status.lockoutRemainingMs > 0) {
+                        startLockoutCountdown(status.lockoutRemainingMs);
+                    } else if (status != null) {
+                        errorText.setVisibility(View.VISIBLE);
+                        String attemptWord = status.remainingAttempts == 1 ? "attempt" : "attempts";
+                        errorText.setText("Incorrect password. You have "
+                                + status.remainingAttempts + " " + attemptWord
+                                + " before the app will be temporarily locked.");
+                    } else {
+                        Toast.makeText(getContext(), "Invalid master password", Toast.LENGTH_SHORT).show();
+                    }
                 });
             } finally {
                 com.pears.pass.autofill.utils.SecureBufferUtils.clearBuffer(passwordBuffer);
@@ -296,6 +399,8 @@ public class MasterPasswordFragment extends BaseAutofillFragment {
                 if (vaultStatus.isLocked) {
                     throw new Exception("Invalid credentials - vault remains locked");
                 }
+
+                if (rateLimit != null) rateLimit.reset();
 
                 if (getActivity() instanceof PasskeyRegistrationActivity) {
                     ((PasskeyRegistrationActivity) getActivity()).onCredentialsObtained(

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/MissingConfigurationFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/MissingConfigurationFragment.java
@@ -35,7 +35,7 @@ public class MissingConfigurationFragment extends BaseAutofillFragment {
                 if (navigationListener != null) navigationListener.onCancel();
             });
         }
-        Button goBackButton = view.findViewById(R.id.missingGoBackButton);
+        Button goBackButton = view.findViewById(R.id.missingV2GoBackButton);
         setupCancelButton(goBackButton);
     }
 }

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/PasskeyFormFragment.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/PasskeyFormFragment.java
@@ -219,6 +219,8 @@ public class PasskeyFormFragment extends Fragment {
         List<String> initialWebsites = new ArrayList<>();
 
         if (existingRecord != null) {
+            saveButton.setText("Save");
+
             Map<String, Object> data = null;
             if (existingRecord.containsKey("data") && existingRecord.get("data") instanceof Map) {
                 data = (Map<String, Object>) existingRecord.get("data");

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/ui/PasskeyRegistrationActivity.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/ui/PasskeyRegistrationActivity.java
@@ -898,6 +898,5 @@ public class PasskeyRegistrationActivity extends AppCompatActivity implements Na
         storedNonce = null;
         storedHashedPassword = null;
         clearSelectedVaultPasswordBuffer();
-        clearPendingPasswordBuffer();
     }
 }

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/utils/AutofillHelper.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/utils/AutofillHelper.java
@@ -20,9 +20,22 @@ public class AutofillHelper {
     private static final String[] PASSWORD_HINTS = {"password", "pswd", "pwd"};
     private static final String[] IGNORED_HINTS = {"search", "find", "recipient", "edit"};
 
+    private static final String[] CARD_NUMBER_KEYWORDS = {"cardnumber", "ccnumber", "cc-number", "card-number", "creditcard"};
+    private static final String[] CARD_EXPIRY_KEYWORDS = {"expir", "exp-date", "cc-exp", "ccexp"};
+    private static final String[] CARD_EXPIRY_MONTH_KEYWORDS = {"exp-month", "expmonth", "cc-exp-month", "ccexpmonth"};
+    private static final String[] CARD_EXPIRY_YEAR_KEYWORDS = {"exp-year", "expyear", "cc-exp-year", "ccexpyear"};
+    private static final String[] CARD_SECURITY_KEYWORDS = {"cvc", "cvv", "csc", "securitycode", "security-code", "cardcode"};
+    private static final String[] CARDHOLDER_KEYWORDS = {"ccname", "cc-name", "cardholder", "card-holder", "cardholdername", "nameoncard"};
+
     public static class ParsedFields {
         private AutofillId usernameId;
         private AutofillId passwordId;
+        private AutofillId cardNumberId;
+        private AutofillId cardExpiryDateId;
+        private AutofillId cardExpiryMonthId;
+        private AutofillId cardExpiryYearId;
+        private AutofillId cardSecurityCodeId;
+        private AutofillId cardholderNameId;
         private String packageName;
         private String webDomain;
         private final List<AutofillId> fallbackFieldIds = new ArrayList<>();
@@ -35,6 +48,15 @@ public class AutofillHelper {
             return passwordId != null;
         }
 
+        public boolean hasCardField() {
+            return cardNumberId != null
+                    || cardExpiryDateId != null
+                    || cardExpiryMonthId != null
+                    || cardExpiryYearId != null
+                    || cardSecurityCodeId != null
+                    || cardholderNameId != null;
+        }
+
         public AutofillId getUsernameId() {
             return usernameId;
         }
@@ -42,6 +64,13 @@ public class AutofillHelper {
         public AutofillId getPasswordId() {
             return passwordId;
         }
+
+        public AutofillId getCardNumberId() { return cardNumberId; }
+        public AutofillId getCardExpiryDateId() { return cardExpiryDateId; }
+        public AutofillId getCardExpiryMonthId() { return cardExpiryMonthId; }
+        public AutofillId getCardExpiryYearId() { return cardExpiryYearId; }
+        public AutofillId getCardSecurityCodeId() { return cardSecurityCodeId; }
+        public AutofillId getCardholderNameId() { return cardholderNameId; }
 
         public String getPackageName() {
             return packageName;
@@ -101,7 +130,25 @@ public class AutofillHelper {
             fields.webDomain = webDomain;
         }
 
-        if (autofillId != null && isUsernameField(autofillHints, inputType, node) && fields.usernameId == null) {
+        if (autofillId != null && isCardNumberField(autofillHints, node) && fields.cardNumberId == null) {
+            fields.cardNumberId = autofillId;
+            SecureLog.d(TAG, "Found card number field");
+        } else if (autofillId != null && isCardExpiryMonthField(autofillHints, node) && fields.cardExpiryMonthId == null) {
+            fields.cardExpiryMonthId = autofillId;
+            SecureLog.d(TAG, "Found card expiry month field");
+        } else if (autofillId != null && isCardExpiryYearField(autofillHints, node) && fields.cardExpiryYearId == null) {
+            fields.cardExpiryYearId = autofillId;
+            SecureLog.d(TAG, "Found card expiry year field");
+        } else if (autofillId != null && isCardExpiryDateField(autofillHints, node) && fields.cardExpiryDateId == null) {
+            fields.cardExpiryDateId = autofillId;
+            SecureLog.d(TAG, "Found card expiry date field");
+        } else if (autofillId != null && isCardSecurityCodeField(autofillHints, node) && fields.cardSecurityCodeId == null) {
+            fields.cardSecurityCodeId = autofillId;
+            SecureLog.d(TAG, "Found card security code field");
+        } else if (autofillId != null && isCardholderNameField(autofillHints, node) && fields.cardholderNameId == null) {
+            fields.cardholderNameId = autofillId;
+            SecureLog.d(TAG, "Found cardholder name field");
+        } else if (autofillId != null && isUsernameField(autofillHints, inputType, node) && fields.usernameId == null) {
             fields.usernameId = autofillId;
             SecureLog.d(TAG, "Found username field");
         } else if (autofillId != null && isPasswordField(autofillHints, inputType, node) && fields.passwordId == null) {
@@ -204,6 +251,92 @@ public class AutofillHelper {
 
         // Check HTML info for web content
         return hasPasswordHtmlAttributes(node);
+    }
+
+    private static boolean matchesCardSignal(String[] hints, AssistStructure.ViewNode node,
+                                             String androidHint, String[] htmlAutocompleteValues,
+                                             String[] keywords) {
+        if (hints != null) {
+            for (String h : hints) {
+                if (h == null) continue;
+                if (androidHint != null && androidHint.equalsIgnoreCase(h)) return true;
+                String hLower = h.toLowerCase();
+                if (htmlAutocompleteValues != null) {
+                    for (String v : htmlAutocompleteValues) {
+                        if (hLower.equals(v)) return true;
+                    }
+                }
+            }
+        }
+
+        String autocomplete = getHtmlAttributeValue(node, "autocomplete");
+        if (autocomplete != null) {
+            String lower = autocomplete.toLowerCase();
+            if (htmlAutocompleteValues != null) {
+                for (String v : htmlAutocompleteValues) {
+                    if (lower.equals(v) || lower.endsWith(" " + v)) return true;
+                }
+            }
+        }
+
+        String hintText = node.getHint() != null ? node.getHint().toString().toLowerCase() : "";
+        String idEntry = node.getIdEntry() != null ? node.getIdEntry().toLowerCase() : "";
+        String name = getHtmlAttributeValue(node, "name");
+        String nameLower = name != null ? name.toLowerCase() : "";
+
+        return containsAnyTerm(hintText, keywords)
+                || containsAnyTerm(idEntry, keywords)
+                || containsAnyTerm(nameLower, keywords);
+    }
+
+    private static boolean isCardNumberField(String[] hints, AssistStructure.ViewNode node) {
+        return matchesCardSignal(hints, node,
+                android.view.View.AUTOFILL_HINT_CREDIT_CARD_NUMBER,
+                new String[]{"cc-number"},
+                CARD_NUMBER_KEYWORDS);
+    }
+
+    private static boolean isCardExpiryDateField(String[] hints, AssistStructure.ViewNode node) {
+        return matchesCardSignal(hints, node,
+                android.view.View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_DATE,
+                new String[]{"cc-exp"},
+                CARD_EXPIRY_KEYWORDS);
+    }
+
+    private static boolean isCardExpiryMonthField(String[] hints, AssistStructure.ViewNode node) {
+        return matchesCardSignal(hints, node,
+                android.view.View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_MONTH,
+                new String[]{"cc-exp-month"},
+                CARD_EXPIRY_MONTH_KEYWORDS);
+    }
+
+    private static boolean isCardExpiryYearField(String[] hints, AssistStructure.ViewNode node) {
+        return matchesCardSignal(hints, node,
+                android.view.View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_YEAR,
+                new String[]{"cc-exp-year"},
+                CARD_EXPIRY_YEAR_KEYWORDS);
+    }
+
+    private static boolean isCardSecurityCodeField(String[] hints, AssistStructure.ViewNode node) {
+        return matchesCardSignal(hints, node,
+                android.view.View.AUTOFILL_HINT_CREDIT_CARD_SECURITY_CODE,
+                new String[]{"cc-csc"},
+                CARD_SECURITY_KEYWORDS);
+    }
+
+    private static boolean isCardholderNameField(String[] hints, AssistStructure.ViewNode node) {
+        return matchesCardSignal(hints, node,
+                null,
+                new String[]{"cc-name"},
+                CARDHOLDER_KEYWORDS);
+    }
+
+    private static String getHtmlAttributeValue(AssistStructure.ViewNode node, String attrName) {
+        ViewStructure.HtmlInfo htmlInfo = node.getHtmlInfo();
+        if (htmlInfo == null) return null;
+        List<Pair<String, String>> attrs = htmlInfo.getAttributes();
+        if (attrs == null) return null;
+        return getHtmlAttribute(attrs, attrName);
     }
 
     /**

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/utils/RateLimitManager.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/utils/RateLimitManager.java
@@ -1,0 +1,92 @@
+package com.pears.pass.autofill.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * Local rate limiter for the autofill master-password screen.
+ * Mirrors the exponential backoff in pearpass-lib-vault-core/worklet/rateLimiter.js,
+ * stored locally because the autofill plugin opens the vault store read-only.
+ */
+public class RateLimitManager {
+    private static final String PREFS = "pp_autofill_rate_limit";
+    private static final String KEY_CONSECUTIVE_FAILURES = "consecutiveFailures";
+    private static final String KEY_LOCKOUT_UNTIL = "lockoutUntil";
+    private static final String KEY_LAST_ATTEMPT_TIME = "lastAttemptTime";
+
+    private static final int MAX_ATTEMPTS = 5;
+    private static final long MAX_BACKOFF_MS = 24L * 60L * 60L * 1000L; // 24h
+    private static final long COOLDOWN_MS = 24L * 60L * 60L * 1000L;    // 24h fresh start
+
+    public static class Status {
+        public final boolean isLocked;
+        public final long lockoutRemainingMs;
+        public final int remainingAttempts;
+
+        public Status(boolean isLocked, long lockoutRemainingMs, int remainingAttempts) {
+            this.isLocked = isLocked;
+            this.lockoutRemainingMs = lockoutRemainingMs;
+            this.remainingAttempts = remainingAttempts;
+        }
+    }
+
+    private final SharedPreferences prefs;
+
+    public RateLimitManager(Context context) {
+        this.prefs = context.getApplicationContext().getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    public Status getStatus() {
+        int failures = prefs.getInt(KEY_CONSECUTIVE_FAILURES, 0);
+        long lockoutUntil = prefs.getLong(KEY_LOCKOUT_UNTIL, 0L);
+        long lastAttempt = prefs.getLong(KEY_LAST_ATTEMPT_TIME, 0L);
+        long now = System.currentTimeMillis();
+
+        if (lastAttempt > 0 && now - lastAttempt >= COOLDOWN_MS) {
+            reset();
+            return new Status(false, 0L, MAX_ATTEMPTS);
+        }
+
+        if (lockoutUntil > 0 && now >= lockoutUntil) {
+            return new Status(false, 0L, 0);
+        }
+
+        boolean isLocked = lockoutUntil > 0;
+        long remainingMs = isLocked ? Math.max(0L, lockoutUntil - now) : 0L;
+        int remaining = isLocked ? 0 : Math.max(0, MAX_ATTEMPTS - failures);
+        return new Status(isLocked, remainingMs, remaining);
+    }
+
+    public void recordFailure() {
+        long now = System.currentTimeMillis();
+        int failures = prefs.getInt(KEY_CONSECUTIVE_FAILURES, 0);
+        long lastAttempt = prefs.getLong(KEY_LAST_ATTEMPT_TIME, 0L);
+        long lockoutUntil = prefs.getLong(KEY_LOCKOUT_UNTIL, 0L);
+
+        if (lastAttempt > 0 && now - lastAttempt >= COOLDOWN_MS) {
+            failures = 0;
+            lockoutUntil = 0L;
+        }
+        if (lockoutUntil > 0 && now >= lockoutUntil) {
+            lockoutUntil = 0L;
+        }
+
+        failures++;
+        long newLockoutUntil = 0L;
+        if (failures >= MAX_ATTEMPTS) {
+            int exponent = failures - MAX_ATTEMPTS + 1;
+            long backoffMs = (long) (Math.pow(2, exponent) * 60L * 1000L);
+            newLockoutUntil = now + Math.min(backoffMs, MAX_BACKOFF_MS);
+        }
+
+        prefs.edit()
+                .putInt(KEY_CONSECUTIVE_FAILURES, failures)
+                .putLong(KEY_LOCKOUT_UNTIL, newLockoutUntil)
+                .putLong(KEY_LAST_ATTEMPT_TIME, now)
+                .apply();
+    }
+
+    public void reset() {
+        prefs.edit().clear().apply();
+    }
+}

--- a/plugins/expo-autofill-plugin/android-template/res/layout/fragment_master_password.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/layout/fragment_master_password.xml
@@ -53,6 +53,17 @@
                 android:id="@+id/masterPwdField"
                 layout="@layout/include_pp_password_field" />
 
+            <TextView
+                android:id="@+id/masterPwdError"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/pp_spacing_s8"
+                android:textAppearance="@style/TextAppearance.PearPass.Label"
+                android:textColor="@color/pp_surface_error"
+                android:visibility="gone"
+                tools:text="Incorrect password. You have 4 attempts before the app will be temporarily locked."
+                tools:visibility="visible" />
+
             <Space
                 android:layout_width="match_parent"
                 android:layout_height="0dp"

--- a/plugins/expo-autofill-plugin/android-template/res/values/autofill_styles.xml
+++ b/plugins/expo-autofill-plugin/android-template/res/values/autofill_styles.xml
@@ -1,20 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    
-    <style name="Theme.PearPass.Autofill.Fullscreen" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowFullscreen">true</item>
-        <item name="android:windowIsTranslucent">false</item>
-        <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:backgroundDimEnabled">false</item>
-        <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowActivityTransitions">false</item>
-        <item name="android:windowCloseOnTouchOutside">false</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
-    </style>
-
-    
     <style name="Theme.PearPass.Autofill.Fullscreen" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowIsTranslucent">true</item>

--- a/plugins/withCustomSplashScreen/src/android/withSplashScreenAndroid.ts
+++ b/plugins/withCustomSplashScreen/src/android/withSplashScreenAndroid.ts
@@ -174,7 +174,7 @@ const withSplashFiles: ConfigPlugin = (config) => {
     // Override ic_launcher_background.xml to use custom_splash_screen
     const launcherBgPath = path.join(drawableDir, 'ic_launcher_background.xml');
     const launcherBgContent = `<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:drawable="@color/splashscreen_background"/>
+  <item android:drawable="@color/splash_background"/>
   <item>
     <bitmap android:gravity="fill" android:src="@drawable/custom_splash_screen"/>
   </item>

--- a/src/jobQueue/handlers/updatePasskeyHandler.js
+++ b/src/jobQueue/handlers/updatePasskeyHandler.js
@@ -3,6 +3,17 @@ import * as FileSystem from 'expo-file-system'
 import { logger } from '../../utils/logger'
 import { getAttachmentsFolderPath } from '../JobFileReader'
 
+const formatWebsites = (urls) =>
+  urls
+    .filter((w) => w && w.trim())
+    .map((w) => {
+      const lower = w.toLowerCase()
+      if (lower.startsWith('http://') || lower.startsWith('https://')) {
+        return lower
+      }
+      return `https://${lower}`
+    })
+
 /**
  * Reads attachment files from pearpass_jobs/attachments/ and converts to { name, buffer }.
  * @param {Array} attachments - Array of { id, name, relativePath } from job payload.
@@ -107,6 +118,10 @@ export const handleUpdatePasskey = async (
     algorithm,
     createdAt,
     transports,
+    title,
+    username,
+    websites,
+    folder,
     note,
     keepAttachmentIds,
     attachments: jobAttachments
@@ -149,11 +164,19 @@ export const handleUpdatePasskey = async (
     ...existingRecord.data,
     credential,
     passkeyCreatedAt: createdAt || Date.now(),
-    ...(note !== null && note !== undefined && { note }),
+    ...(title !== undefined && title !== null && title !== '' && { title }),
+    ...(username !== undefined && { username: username ?? '' }),
+    ...(websites !== undefined && { websites: formatWebsites(websites || []) }),
+    ...(note !== undefined && { note: note ?? '' }),
     attachments: [...keptAttachments, ...newAttachments]
   }
 
-  await updateRecord(existingRecordId, { data: updatedData })
+  const updates = { data: updatedData }
+  if (folder !== undefined) {
+    updates.folder = folder
+  }
+
+  await updateRecord(existingRecordId, updates)
 
   await cleanupJobAttachments(jobAttachments || [])
 }

--- a/src/jobQueue/handlers/updatePasskeyHandler.test.js
+++ b/src/jobQueue/handlers/updatePasskeyHandler.test.js
@@ -186,6 +186,108 @@ describe('handleUpdatePasskey', () => {
     )
   })
 
+  it('should update title/username/websites when payload includes them', async () => {
+    const payload = {
+      existingRecordId: 'rec-1',
+      credentialId: 'new-cred',
+      title: 'New Title',
+      username: 'new-user@example.com',
+      websites: ['https://new.example.com', 'NEW2.example.com']
+    }
+
+    await handleUpdatePasskey(payload, deps)
+
+    expect(mockUpdateRecord).toHaveBeenCalledWith(
+      'rec-1',
+      expect.objectContaining({
+        data: expect.objectContaining({
+          title: 'New Title',
+          username: 'new-user@example.com',
+          websites: ['https://new.example.com', 'https://new2.example.com']
+        })
+      })
+    )
+  })
+
+  it('should ignore an empty title to keep the existing one', async () => {
+    const payload = {
+      existingRecordId: 'rec-1',
+      credentialId: 'new-cred',
+      title: ''
+    }
+
+    await handleUpdatePasskey(payload, deps)
+
+    expect(mockUpdateRecord).toHaveBeenCalledWith(
+      'rec-1',
+      expect.objectContaining({
+        data: expect.objectContaining({
+          title: 'Existing Record'
+        })
+      })
+    )
+  })
+
+  it('should update folder at the top level when payload includes it', async () => {
+    mockGetRecord.mockResolvedValue({
+      ...existingRecord,
+      folder: 'OldFolder',
+      data: { ...existingRecord.data }
+    })
+
+    const payload = {
+      existingRecordId: 'rec-1',
+      credentialId: 'new-cred',
+      folder: 'NewFolder'
+    }
+
+    await handleUpdatePasskey(payload, deps)
+
+    expect(mockUpdateRecord).toHaveBeenCalledWith(
+      'rec-1',
+      expect.objectContaining({ folder: 'NewFolder' })
+    )
+  })
+
+  it('should clear folder when payload sends null', async () => {
+    mockGetRecord.mockResolvedValue({
+      ...existingRecord,
+      folder: 'OldFolder',
+      data: { ...existingRecord.data }
+    })
+
+    const payload = {
+      existingRecordId: 'rec-1',
+      credentialId: 'new-cred',
+      folder: null
+    }
+
+    await handleUpdatePasskey(payload, deps)
+
+    expect(mockUpdateRecord).toHaveBeenCalledWith(
+      'rec-1',
+      expect.objectContaining({ folder: null })
+    )
+  })
+
+  it('should not touch folder when payload omits it (iOS path)', async () => {
+    mockGetRecord.mockResolvedValue({
+      ...existingRecord,
+      folder: 'KeepFolder',
+      data: { ...existingRecord.data }
+    })
+
+    const payload = {
+      existingRecordId: 'rec-1',
+      credentialId: 'new-cred'
+    }
+
+    await handleUpdatePasskey(payload, deps)
+
+    const updates = mockUpdateRecord.mock.calls[0][1]
+    expect('folder' in updates).toBe(false)
+  })
+
   it('should keep only specified existing attachments', async () => {
     const record = {
       data: {


### PR DESCRIPTION
### Requirements
<!-- List the requirements for this PR -->

### Changes
<!-- Summarize the changes introduced in this PR -->

- [Android][Passkey] The "Save and Add Login" button is displayed on the Passkey screen when adding a Passkey to the existing Login item

- [Android][Passkey "login" screen] There is no limit on the number of password entry attempts

- [Android/][Passkey "login" screen] There is no limit on the number of password entry attempts

- Add an autofill for the "Credit card" item as it was implemented for the "Login" item

- [v2][Android/iOS]["Autofill" screen][Item list] All items are displayed when there are no appropriate items


### Testing Notes
<!-- How did you test it? -->
Android Emulator

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

[Android][Passkey] The "Save and Add Login" button is displayed on the Passkey screen when adding a Passkey to the existing Login item

https://github.com/user-attachments/assets/fcff261d-5565-400d-9e99-bac73b2cbce1




[Android][Passkey "login" screen] There is no limit on the number of password entry attempts

https://github.com/user-attachments/assets/cdd5bd61-3b4d-42f2-8991-b581f04ca0f8



[Android/][Passkey "login" screen] There is no limit on the number of password entry attempts

https://github.com/user-attachments/assets/31e63a4e-4535-47fd-90f9-93b2e61ab85a



Add an autofill for the "Credit card" item as it was implemented for the "Login" item
[v2][Android/iOS]["Autofill" screen][Item list] All items are displayed when there are no appropriate items

https://github.com/user-attachments/assets/fdf9adbd-40ed-46d4-b157-99e4fb051169


