### PR TITLE
Fix/passkeyi os autofill

### DIFF
--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/DocumentPickerView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/DocumentPickerView.swift
@@ -1,0 +1,43 @@
+//
+//  DocumentPickerView.swift
+//  PearPassAutoFillExtension
+//
+//  SwiftUI wrapper around UIDocumentPickerViewController for picking files
+//  to attach to passkey records.
+//
+
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+
+struct DocumentPickerView: UIViewControllerRepresentable {
+    let onPick: (URL) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPick: onPick)
+    }
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.item], asCopy: true)
+        picker.allowsMultipleSelection = false
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    final class Coordinator: NSObject, UIDocumentPickerDelegate {
+        private let onPick: (URL) -> Void
+
+        init(onPick: @escaping (URL) -> Void) {
+            self.onPick = onPick
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            guard let url = urls.first else { return }
+            onPick(url)
+        }
+
+        func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {}
+    }
+}

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/HostView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/HostView.swift
@@ -51,6 +51,12 @@ struct HostView: View {
     /// password screen — invalid password, missing keychain data, biometric
     /// cancel, etc. Cleared when a new auth attempt starts.
     @State private var masterPasswordError: String? = nil
+    /// Rate limiter for the master-password screen — counts failed unlocks and
+    /// applies an exponential lockout so the extension can't be brute-forced.
+    private let rateLimit = RateLimitManager()
+    @State private var rateLimitMessage: String? = nil
+    @State private var isRateLimited: Bool = false
+    @State private var lockoutCountdownTask: Task<Void, Never>? = nil
     /// Sticky once the user has typed any non-empty query; clearing the search
     /// after that point shows the full vault instead of re-applying the
     /// initial domain filter (mirrors Android behavior).
@@ -245,11 +251,15 @@ struct HostView: View {
                     : NSLocalizedString("Sign in", comment: "sheet header — credential assertion"),
                 password: bindingFor(\.masterPassword),
                 isAuthenticating: isAuthenticating,
+                rateLimitMessage: rateLimitMessage,
+                isRateLimited: isRateLimited,
                 onClose: handleClose,
                 onContinue: handleMasterPasswordContinue,
                 onFaceIDLogin: handleFaceIDLogin,
                 onPasskeyLogin: handlePasskeyLogin
             )
+            .onAppear { applyRateLimitStatus(rateLimit.getStatus()) }
+            .onDisappear { lockoutCountdownTask?.cancel(); lockoutCountdownTask = nil }
 
         case .vaultSelection, .vaultPassword, .credentialsList:
             CombinedItemsView(
@@ -414,6 +424,7 @@ struct HostView: View {
         }
         let password = viewModel.masterPassword
         guard !password.isEmpty else { return }
+        if isRateLimited { return }
 
         isAuthenticating = true
         masterPasswordError = nil
@@ -428,6 +439,9 @@ struct HostView: View {
                 let vaults = try await client.listVaults()
 
                 await MainActor.run {
+                    rateLimit.reset()
+                    rateLimitMessage = nil
+                    isRateLimited = false
                     isAuthenticating = false
                     let sortedVaults = sortedByMostRecent(vaults)
                     viewModel.vaults = sortedVaults
@@ -440,12 +454,66 @@ struct HostView: View {
                 }
             } catch {
                 NSLog("[HostView] master-password unlock error: \(error)")
+                rateLimit.recordFailure()
+                let status = rateLimit.getStatus()
                 await MainActor.run {
                     isAuthenticating = false
-                    showAuthErrorToast(NSLocalizedString("Invalid master password", comment: "Invalid master password error"))
+                    viewModel.masterPassword = ""
+                    applyRateLimitStatus(status, justFailed: true)
                 }
             }
         }
+    }
+
+    private func applyRateLimitStatus(_ status: RateLimitManager.Status, justFailed: Bool = false) {
+        if status.isLocked && status.lockoutRemainingMs > 0 {
+            isRateLimited = true
+            startLockoutCountdown(remainingMs: status.lockoutRemainingMs)
+            return
+        }
+
+        lockoutCountdownTask?.cancel()
+        lockoutCountdownTask = nil
+        isRateLimited = false
+
+        if justFailed {
+            let word = status.remainingAttempts == 1 ? "attempt" : "attempts"
+            rateLimitMessage = "Incorrect password. You have \(status.remainingAttempts) \(word) before the app will be temporarily locked."
+        } else {
+            rateLimitMessage = nil
+        }
+    }
+
+    private func startLockoutCountdown(remainingMs: Int64) {
+        lockoutCountdownTask?.cancel()
+        rateLimitMessage = formatLockoutMessage(remainingMs)
+
+        lockoutCountdownTask = Task { @MainActor in
+            var remaining = remainingMs
+            while remaining > 0 && !Task.isCancelled {
+                rateLimitMessage = formatLockoutMessage(remaining)
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                remaining -= 1000
+            }
+            if !Task.isCancelled {
+                applyRateLimitStatus(rateLimit.getStatus())
+            }
+        }
+    }
+
+    private func formatLockoutMessage(_ remainingMs: Int64) -> String {
+        let totalSeconds = max(1, (remainingMs + 999) / 1000)
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        let when: String
+        if minutes > 0 && seconds > 0 {
+            when = "\(minutes)m \(seconds)s"
+        } else if minutes > 0 {
+            when = "\(minutes)m"
+        } else {
+            when = "\(seconds)s"
+        }
+        return "Too many attempts. Try again in \(when)."
     }
 
     /// Mirrors V1 MasterPasswordView.handleFaceIDLogin — fetch the keychain
@@ -488,6 +556,9 @@ struct HostView: View {
                 let vaults = try await client.listVaults()
 
                 await MainActor.run {
+                    rateLimit.reset()
+                    rateLimitMessage = nil
+                    isRateLimited = false
                     isAuthenticating = false
                     let sortedVaults = sortedByMostRecent(vaults)
                     viewModel.vaults = sortedVaults

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/HostView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/HostView.swift
@@ -312,6 +312,7 @@ struct HostView: View {
             websiteError: $formWebsiteError,
             saveError: formSaveError,
             isSaving: isSavingPasskey,
+            isExistingRecord: selectedExistingRecord != nil,
             onBack: { showPasskeyForm = false },
             onClose: handleClose,
             onSave: handleFormSave,

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/HostView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/HostView.swift
@@ -1205,6 +1205,7 @@ struct HostView: View {
         if mode == .registration { return records }
         let isPasskeyAssertion = (passkeyRpId?.isEmpty == false)
         return records.filter { record in
+            guard record.type == "login" else { return false }
             let isPasskey = record.data?.credential != nil
             return isPasskeyAssertion ? isPasskey : !isPasskey
         }

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/Job.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/Job.swift
@@ -120,6 +120,10 @@ struct UpdatePasskeyPayload: Codable {
     let createdAt: Double
     let transports: [String]
     let vaultId: String
+    var title: String?
+    var username: String?
+    var websites: [String]?
+    var folder: String?
     var note: String?
     var attachments: [JobAttachment] = []
     var keepAttachmentIds: [String] = []

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/MasterPasswordView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/MasterPasswordView.swift
@@ -19,6 +19,13 @@ struct MasterPasswordView: View {
     /// are surfaced via the toast overlay rendered in HostView, not inline.
     var isAuthenticating: Bool = false
 
+    /// Inline message shown below the password field — either "X attempts
+    /// remaining" or the lockout countdown.
+    var rateLimitMessage: String? = nil
+    /// When true, the Continue button + password input are disabled because
+    /// the rate limiter has locked the screen.
+    var isRateLimited: Bool = false
+
     var onClose: () -> Void = {}
     var onContinue: () -> Void = {}
     /// Fired when the user taps the biometric button. Hidden when biometrics
@@ -78,7 +85,7 @@ struct MasterPasswordView: View {
     }
 
     private var continueEnabled: Bool {
-        !password.isEmpty && !isAuthenticating
+        !password.isEmpty && !isAuthenticating && !isRateLimited
     }
 
     var body: some View {
@@ -115,6 +122,15 @@ struct MasterPasswordView: View {
                             text: $password,
                             placeholder: NSLocalizedString("Enter Master Password", comment: "password input placeholder")
                         )
+
+                        if let rateLimitMessage = rateLimitMessage, !rateLimitMessage.isEmpty {
+                            Text(rateLimitMessage)
+                                .font(PPTypography.label)
+                                .foregroundColor(PPColors.surfaceError)
+                                .multilineTextAlignment(.leading)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.top, PPSpacing.s8)
+                        }
 
                         Spacer()
 

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/Models.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/Models.swift
@@ -51,6 +51,24 @@ struct AttachmentMetadata: Equatable {
     let name: String
 }
 
+struct AttachmentFile: Equatable {
+    let id: String
+    let name: String
+    let data: Data
+}
+
+struct PasskeyFormData {
+    let title: String
+    let username: String
+    let websites: [String]
+    let note: String
+    let folder: String?
+    let attachments: [AttachmentFile]
+    let keepAttachmentIds: [String]
+    let passkeyCreatedAt: Int64
+    let existingRecord: VaultRecord?
+}
+
 struct RecordData {
     let title: String
     let username: String

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/Models.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/Models.swift
@@ -51,7 +51,7 @@ struct AttachmentMetadata: Equatable {
     let name: String
 }
 
-struct AttachmentFile: Equatable {
+struct AttachmentFile: Equatable, Identifiable {
     let id: String
     let name: String
     let data: Data

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PasskeyFormView.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PasskeyFormView.swift
@@ -42,6 +42,9 @@ struct PasskeyFormView: View {
     /// ADD/UPDATE job is being written so the user cannot fire the save
     /// twice or dismiss mid-flight.
     var isSaving: Bool = false
+    /// True when attaching a passkey to an already-existing Login record.
+    /// Drives the primary button label.
+    var isExistingRecord: Bool = false
 
     @State private var showFolderPicker: Bool = false
     @State private var showFilePicker: Bool = false
@@ -240,7 +243,9 @@ struct PasskeyFormView: View {
                             }
 
                             PPButton(
-                                title: NSLocalizedString("Save & Add Login", comment: "save button"),
+                                title: isExistingRecord
+                                    ? NSLocalizedString("Save", comment: "save button — existing record")
+                                    : NSLocalizedString("Save & Add Login", comment: "save button"),
                                 variant: .primary,
                                 isEnabled: !isSaving,
                                 isLoading: isSaving,

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PasskeyJobCreator.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/PasskeyJobCreator.swift
@@ -197,7 +197,11 @@ enum PasskeyJobCreator {
             createdAt: Double(passkeyCreatedAt),
             transports: credential.response.transports,
             vaultId: vaultId,
-            note: formData.note.isEmpty ? nil : formData.note,
+            title: formData.title,
+            username: formData.username,
+            websites: formData.websites,
+            folder: formData.folder,
+            note: formData.note,
             attachments: jobAttachments,
             keepAttachmentIds: formData.keepAttachmentIds
         )

--- a/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/RateLimitManager.swift
+++ b/plugins/expo-autofill-plugin/ios-template/PearPassAutofillExtension/RateLimitManager.swift
@@ -1,0 +1,91 @@
+//
+//  RateLimitManager.swift
+//  PearPassAutoFillExtension
+//
+//  Local rate limiter for the autofill master-password screen.
+//  Mirrors pearpass-lib-vault-core/worklet/rateLimiter.js. Stored locally
+//  because the autofill extension opens the vault store read-only.
+//
+
+import Foundation
+
+final class RateLimitManager {
+    struct Status {
+        let isLocked: Bool
+        let lockoutRemainingMs: Int64
+        let remainingAttempts: Int
+    }
+
+    private static let suiteName = "pp.autofill.rateLimit"
+    private static let keyFailures = "consecutiveFailures"
+    private static let keyLockoutUntil = "lockoutUntil"
+    private static let keyLastAttempt = "lastAttemptTime"
+
+    private static let maxAttempts = 5
+    private static let maxBackoffMs: Int64 = 24 * 60 * 60 * 1000      // 24h
+    private static let cooldownMs: Int64 = 24 * 60 * 60 * 1000         // 24h fresh start
+
+    private let defaults: UserDefaults
+
+    init() {
+        self.defaults = UserDefaults(suiteName: Self.suiteName) ?? .standard
+    }
+
+    func getStatus() -> Status {
+        let failures = defaults.integer(forKey: Self.keyFailures)
+        let lockoutUntil = (defaults.object(forKey: Self.keyLockoutUntil) as? NSNumber)?.int64Value ?? 0
+        let lastAttempt = (defaults.object(forKey: Self.keyLastAttempt) as? NSNumber)?.int64Value ?? 0
+        let now = Self.nowMs()
+
+        if lastAttempt > 0 && now - lastAttempt >= Self.cooldownMs {
+            reset()
+            return Status(isLocked: false, lockoutRemainingMs: 0, remainingAttempts: Self.maxAttempts)
+        }
+
+        if lockoutUntil > 0 && now >= lockoutUntil {
+            return Status(isLocked: false, lockoutRemainingMs: 0, remainingAttempts: 0)
+        }
+
+        let isLocked = lockoutUntil > 0
+        let remainingMs = isLocked ? max(0, lockoutUntil - now) : 0
+        let remaining = isLocked ? 0 : max(0, Self.maxAttempts - failures)
+        return Status(isLocked: isLocked, lockoutRemainingMs: remainingMs, remainingAttempts: remaining)
+    }
+
+    func recordFailure() {
+        let now = Self.nowMs()
+        var failures = defaults.integer(forKey: Self.keyFailures)
+        let lastAttempt = (defaults.object(forKey: Self.keyLastAttempt) as? NSNumber)?.int64Value ?? 0
+        var lockoutUntil = (defaults.object(forKey: Self.keyLockoutUntil) as? NSNumber)?.int64Value ?? 0
+
+        if lastAttempt > 0 && now - lastAttempt >= Self.cooldownMs {
+            failures = 0
+            lockoutUntil = 0
+        }
+        if lockoutUntil > 0 && now >= lockoutUntil {
+            lockoutUntil = 0
+        }
+
+        failures += 1
+        var newLockoutUntil: Int64 = 0
+        if failures >= Self.maxAttempts {
+            let exponent = failures - Self.maxAttempts + 1
+            let backoffMs = Int64(pow(2.0, Double(exponent)) * 60.0 * 1000.0)
+            newLockoutUntil = now + min(backoffMs, Self.maxBackoffMs)
+        }
+
+        defaults.set(failures, forKey: Self.keyFailures)
+        defaults.set(NSNumber(value: newLockoutUntil), forKey: Self.keyLockoutUntil)
+        defaults.set(NSNumber(value: now), forKey: Self.keyLastAttempt)
+    }
+
+    func reset() {
+        defaults.removeObject(forKey: Self.keyFailures)
+        defaults.removeObject(forKey: Self.keyLockoutUntil)
+        defaults.removeObject(forKey: Self.keyLastAttempt)
+    }
+
+    private static func nowMs() -> Int64 {
+        Int64(Date().timeIntervalSince1970 * 1000)
+    }
+}


### PR DESCRIPTION
### Changes
<!-- Summarize the changes introduced in this PR -->
[Android][Passkey] The "Save and Add Login" button is displayed on the Passkey screen when adding a Passkey to the existing Login item

[Android][Passkey "login" screen] There is no limit on the number of password entry attempts

[Android/][Passkey "login" screen] There is no limit on the number of password entry attempts

Add an autofill for the "Credit card" item as it was implemented for the "Login" item

[v2][Android/iOS]["Autofill" screen][Item list] All items are displayed when there are no appropriate items

### Testing Notes
<!-- How did you test it? -->
IOS simulator



https://github.com/user-attachments/assets/18a90b47-f813-4961-86be-740be67bfaeb

https://github.com/user-attachments/assets/556219d2-31f8-435e-9431-d412d70a78f1

https://github.com/user-attachments/assets/23f0a987-9df6-41b4-970f-d89ede032f2d

https://github.com/user-attachments/assets/33de517e-18d4-49a0-95a2-62be5f564018



