### PR TITLE
Fix overlapping and broken ui after discarding unsaved changes in blind peering

### DIFF
--- a/src/screens/Settings/TabPrivacy/BlindPeeringSection.jsx
+++ b/src/screens/Settings/TabPrivacy/BlindPeeringSection.jsx
@@ -32,6 +32,7 @@ import { BackScreenHeader } from 'src/containers/ScreenHeader/BackScreenHeader'
 import { UnsavedChangesSheet } from '../../../containers/BottomSheet/UnsavedChangesSheet'
 import { useBottomSheet } from '../../../context/BottomSheetContext'
 import { useLoadingContext } from '../../../context/LoadingContext'
+import { openAfterKeyboardDismiss } from '../../../utils/openAfterKeyboardDismiss'
 
 const { DEFAULT, PERSONAL } = BLIND_PEER_TYPE
 
@@ -252,20 +253,22 @@ export const BlindPeeringSection = () => {
           navigation.dispatch(e.data.action)
         }
 
-        expand({
-          children: (
-            <UnsavedChangesSheet
-              description={t`You have unsaved changes to your Blind Peering settings. Would you like to save them before leaving?`}
-              onClose={collapse}
-              onDiscard={proceed}
-              onSave={async () => {
-                collapse()
-                const ok = await performSaveRef.current()
-                if (ok) navigation.dispatch(e.data.action)
-              }}
-            />
-          )
-        })
+        openAfterKeyboardDismiss(() =>
+          expand({
+            children: (
+              <UnsavedChangesSheet
+                description={t`You have unsaved changes to your Blind Peering settings. Would you like to save them before leaving?`}
+                onClose={collapse}
+                onDiscard={proceed}
+                onSave={async () => {
+                  collapse()
+                  const ok = await performSaveRef.current()
+                  if (ok) navigation.dispatch(e.data.action)
+                }}
+              />
+            )
+          })
+        )
       })
 
       return sub


### PR DESCRIPTION
### Requirements
<!-- List the requirements for this PR -->
Unsaved changes bottom sheet is not overlapped by keyboard
Ui is not broken after discarding changes

### Changes
<!-- Summarize the changes introduced in this PR -->

### Testing Notes
<!-- How did you test it? -->

### Things reviewers should pay attention to
<!-- Highlight anything specific you want reviewers to focus on -->

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

https://github.com/user-attachments/assets/1dce7eb9-80d1-44ed-bdbf-c1e31aa77634

[android.webm](https://github.com/user-attachments/assets/0c8d9422-0646-4d8f-bccd-7d7158dce0be)


### dependencies
<!-- List any dependent work items or PRs -->
