### PR TITLE
(Android) Fix/autofill credentials list always empty (IPC response truncation), and missing encryption salt field

### DIFF
--- a/plugins/expo-autofill-plugin/android-template/java/autofill/data/BareHelper.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/data/BareHelper.java
@@ -6,6 +6,7 @@ import android.os.Looper;
 import com.pears.pass.autofill.utils.SecureLog;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import to.holepunch.bare.kit.IPC;
@@ -216,37 +217,11 @@ public class BareHelper {
 
                 SecureLog.d(TAG, "Message written successfully, now reading response");
 
-                // Read inside the write callback, exactly like the example
-                ipc.read((replyData, readException) -> {
-                    if (readException != null) {
-                        SecureLog.e(TAG, "Read failed", readException);
-                        if (callback != null) {
-                            callback.onResponse(null, readException);
-                        }
-                        return;
-                    }
-
-                    if (replyData == null || replyData.remaining() == 0) {
-                        SecureLog.w(TAG, "No reply data received");
-                        if (callback != null) {
-                            callback.onResponse(null, new Exception("No reply data received"));
-                        }
-                        return;
-                    }
-
-                    try {
-                        String reply = StandardCharsets.UTF_8.decode(replyData).toString();
-                        SecureLog.d(TAG, "Received reply: " + reply);
-                        if (callback != null) {
-                            callback.onResponse(reply, null);
-                        }
-                    } catch (Exception e) {
-                        SecureLog.e(TAG, "Failed to decode reply", e);
-                        if (callback != null) {
-                            callback.onResponse(null, e);
-                        }
-                    }
-                });
+                // Read the response using length-prefixed framing.
+                // The worklet sends: [4-byte Uint32LE totalLength][data...]
+                // Created via FramedStream on the JS side — read the 4-byte
+                // length prefix first, then accumulate payload bytes.
+                readLengthPrefix(new ByteArrayOutputStream(), callback);
             });
 
         } catch (Exception e) {
@@ -255,6 +230,104 @@ public class BareHelper {
                 callback.onResponse(null, e);
             }
         }
+    }
+
+    /** Maximum bytes we'll accumulate per response (10MB). */
+    private static final int MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+
+    /**
+     * Read a 4-byte length prefix from IPC, then read that many payload bytes
+     * across potentially multiple IPC reads.
+     */
+    private void readLengthPrefix(ByteArrayOutputStream accumulator, SendCallback callback) {
+        ipc.read((replyData, readException) -> {
+            if (readException != null) {
+                SecureLog.e(TAG, "Read failed", readException);
+                if (callback != null) {
+                    callback.onResponse(null, readException);
+                }
+                return;
+            }
+
+            if (replyData == null || replyData.remaining() == 0) {
+                SecureLog.w(TAG, "No reply data received");
+                if (callback != null) {
+                    callback.onResponse(null, new Exception("No reply data received"));
+                }
+                return;
+            }
+
+            // Read this chunk
+            byte[] chunk = new byte[replyData.remaining()];
+            replyData.get(chunk);
+            accumulator.write(chunk, 0, chunk.length);
+            byte[] accumulated = accumulator.toByteArray();
+
+            // Accumulate until we have 4 bytes for the length prefix
+            if (accumulated.length < 4) {
+                readLengthPrefix(accumulator, callback);
+                return;
+            }
+            int totalLen = ((accumulated[0] & 0xFF)) |
+                          ((accumulated[1] & 0xFF) << 8) |
+                          ((accumulated[2] & 0xFF) << 16) |
+                          ((accumulated[3] & 0xFF) << 24);
+            if (totalLen <= 0 || totalLen > MAX_RESPONSE_BYTES) {
+                SecureLog.e(TAG, "Invalid response length: " + totalLen);
+                if (callback != null) {
+                    callback.onResponse(null, new Exception("Invalid response length: " + totalLen));
+                }
+                return;
+            }
+            SecureLog.d(TAG, "Response length prefix: " + totalLen + " bytes");
+            // Reset accumulator and proceed to read payload
+            ByteArrayOutputStream payloadAccum = new ByteArrayOutputStream(totalLen);
+            // Move any excess bytes beyond the 4-byte prefix into the payload
+            if (accumulated.length > 4) {
+                payloadAccum.write(accumulated, 4, accumulated.length - 4);
+            }
+            readPayload(payloadAccum, totalLen, callback);
+        });
+    }
+
+    private void readPayload(ByteArrayOutputStream accumulator, int totalLen, SendCallback callback) {
+        // If we already have enough bytes, decode and return
+        if (accumulator.size() >= totalLen) {
+            byte[] data = accumulator.toByteArray();
+            String reply = new String(data, 0, totalLen, StandardCharsets.UTF_8);
+            SecureLog.d(TAG, "Complete response received (" + totalLen + " bytes)");
+            if (callback != null) {
+                callback.onResponse(reply, null);
+            }
+            return;
+        }
+
+        // Need more data — read next chunk
+        ipc.read((replyData, readException) -> {
+            if (readException != null) {
+                SecureLog.e(TAG, "Read failed during payload", readException);
+                if (callback != null) {
+                    callback.onResponse(null, readException);
+                }
+                return;
+            }
+
+            if (replyData == null || replyData.remaining() == 0) {
+                // No more data but we haven't reached totalLen — truncated
+                byte[] partial = accumulator.toByteArray();
+                SecureLog.e(TAG, "Response truncated: got " + accumulator.size() + "/" + totalLen + " bytes");
+                if (callback != null) {
+                    callback.onResponse(null, new Exception("Response truncated: " + accumulator.size() + "/" + totalLen + " bytes"));
+                }
+                return;
+            }
+
+            byte[] chunk = new byte[replyData.remaining()];
+            replyData.get(chunk);
+            accumulator.write(chunk, 0, chunk.length);
+
+            readPayload(accumulator, totalLen, callback);
+        });
     }
 
 

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/data/PearPassVaultClient.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/data/PearPassVaultClient.java
@@ -871,7 +871,7 @@ public class PearPassVaultClient {
                             String salt = (String) encryptionData.get("salt");
                             String hashedPassword = (String) encryptionData.get("hashedPassword");
 
-                            if (ciphertext != null && nonce != null && salt != null) {
+                            if (ciphertext != null && nonce != null) {
                                 log("Successfully parsed master password encryption from initialized data");
                                 return new MasterPasswordEncryption(ciphertext, nonce, salt, hashedPassword);
                             }
@@ -906,7 +906,7 @@ public class PearPassVaultClient {
                         String salt = (String) encryptionData.get("salt");
                         String hashedPassword = (String) encryptionData.get("hashedPassword");
 
-                        if (ciphertext != null && nonce != null && salt != null) {
+                        if (ciphertext != null && nonce != null) {
                             log("Successfully parsed master password encryption from existing data");
                             return new MasterPasswordEncryption(ciphertext, nonce, salt, hashedPassword);
                         }
@@ -995,7 +995,7 @@ public class PearPassVaultClient {
                     String salt = (String) data.get("salt");
                     String hashedPassword = (String) data.get("hashedPassword");
 
-                    if (ciphertext != null && nonce != null && salt != null) {
+                    if (ciphertext != null && nonce != null) {
                         return new MasterPasswordEncryption(ciphertext, nonce, salt, hashedPassword);
                     }
                     return null;

--- a/plugins/expo-autofill-plugin/android-template/java/autofill/utils/VaultInitializer.java
+++ b/plugins/expo-autofill-plugin/android-template/java/autofill/utils/VaultInitializer.java
@@ -97,8 +97,7 @@ public class VaultInitializer {
                 // Check if password is set
                 boolean hasPasswordSet = encryption != null &&
                         encryption.ciphertext != null &&
-                        encryption.nonce != null &&
-                        encryption.salt != null;
+                        encryption.nonce != null;
 
                 // Check if user is logged in (vault is initialized and unlocked)
                 boolean isLoggedIn = vaultsStatus.isInitialized && !vaultsStatus.isLocked;
@@ -167,8 +166,7 @@ public class VaultInitializer {
                     client.getMasterPasswordEncryption(null).get();
             return encryption != null &&
                     encryption.ciphertext != null &&
-                    encryption.nonce != null &&
-                    encryption.salt != null;
+                    encryption.nonce != null;
         } catch (Exception e) {
             SecureLog.e(TAG, "Could not check password status: " + e.getMessage());
             return false;


### PR DESCRIPTION
### Requirements
- The autofill activity had two issues: 1. Entering the correct password resulted resulted in an infinite spinner, and 2. Using biometrics resulted in an empty credentials list. 2. was reported as issue #458 
- Root causes:
  - Master encryption data from the worklet lacks a salt field, but the autofill reader required it.
  - The activeVaultList() response for vaults with many records exceeds the ~64KB internal IPC buffer, truncating the JSON mid-stream

### Changes
- PearPassVaultClient.java / VaultInitializer.java: Removed salt != null requirement from getMasterPasswordEncryption(), getMasterEncryption(), and hasPasswordSet checks. decryptVaultKey() only needs hashedPassword, so requiring salt was overly strict. checkVaultIsProtected() still validates salt for per-vault passwords.
- app-ipc.js: Route reply() through FramedStream (from the framed-stream package), which prepends a 4-byte Uint32LE payload length — the same framing the main app's RPC + FramedStream path uses.
- BareHelper.java: Replaced single ipc.read() with a framed reader that reads the 4-byte length prefix first, then loops on ipc.read() until the full payload is accumulated, handling truncation at the IPC's internal buffer limit.

### Testing Notes
- Tested with a dev build on my Pixel 7a, Android 17. Opened an autofill in the bluesky app, unlocked with both the the master password and the biometric options, verified the list populates, search works, and the fields get autofilled.
- CombinedItemsFragment log shows activeVaultList returning non-zero records after fix

### Things reviewers should pay attention to
- The FramedStream framing is only applied to outgoing responses (from worklet → Java). Incoming requests remainunframed via ipc.on('data') since they never exceed the 64KB limit.
- BareHelper is only for the autofill activity; the main app uses the React Native bridge and is unaffected by these changes.
- Disclosure: A majority of the work was done using Hermes Agent hooked up to deepseek v4 flash (preview). I reviewed the changes myself, but if there is anything untoward, please let me know. I made these fixes so I could actually use this app with my 400+ passwords (and be able to use the master password if my fingerprint ever failed, without having to back out to the main app where the password works).

### Screenshots/Recordings
- I can get before/after videos and logs if necessary.

### dependencies
